### PR TITLE
Add ChakraCore as a target

### DIFF
--- a/Sources/FuzzilliCli/Profiles/ChakraProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/ChakraProfile.swift
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fuzzilli
+
+fileprivate func ForceSimpleJitCompilationGenerator(_ b: ProgramBuilder) {
+    let f = b.randVar(ofType: .Function)
+    let arguments = generateCallArguments(b, n: Int.random(in: 2...5))
+
+    b.forLoop(b.loadInt(0), .lessThan, b.loadInt(10), .Add, b.loadInt(1)) { _ in
+        b.callFunction(f, withArgs: arguments)
+    }
+}
+
+fileprivate func ForceFullJitCompilationGenerator(_ b: ProgramBuilder) {
+    let f = b.randVar(ofType: .Function)
+    let arguments = generateCallArguments(b, n: Int.random(in: 2...5))
+
+    b.forLoop(b.loadInt(0), .lessThan, b.loadInt(100), .Add, b.loadInt(1)) { _ in
+        b.callFunction(f, withArgs: arguments)
+    }
+}
+
+let chakraProfile = Profile(
+    processArguments: ["-maxinterpretcount:10",
+                       "-maxsimplejitruncount:100",
+                       "-bgjit-",
+                       "-oopjit-",
+                       "-reprl",
+                       "fuzzcode.js"],
+
+    processEnv: ["UBSAN_OPTIONS":"handle_segv=0"],
+
+    codePrefix: """
+                function main() {
+                """,
+
+    codeSuffix: """
+                }
+                main();
+                """,
+
+    crashTests: ["crash(0)", "crash(1)", "crash(2)"],
+
+    additionalCodeGenerators: WeightedList<CodeGenerator>([
+        (ForceSimpleJitCompilationGenerator, 5),
+        (ForceFullJitCompilationGenerator, 5),
+    ]),
+
+    builtins: defaultBuiltins,
+    propertyNames: defaultPropertyNames,
+    methodNames: defaultMethodNames
+)

--- a/Sources/FuzzilliCli/Profiles/Profile.swift
+++ b/Sources/FuzzilliCli/Profiles/Profile.swift
@@ -35,4 +35,5 @@ let profiles = [
     "jsc": jscProfile,
     "spidermonkey": spidermonkeyProfile,
     "v8": v8Profile,
+    "chakra": chakraProfile,
 ]

--- a/Targets/ChakraCore/README.md
+++ b/Targets/ChakraCore/README.md
@@ -1,0 +1,8 @@
+# Target: ChakraCore
+
+To build ChakraCore (ch) for fuzzing:
+
+1. Clone the ChakraCore from https://github.com/microsoft/ChakraCore
+2. Apply chakracore.patch. The patch should apply cleanly to git commit 9296ec533c56ba50696868e531d3ec5d0994ed62
+3. Run the fuzzbuild.sh script in the ChakraCore root directory
+4. FuzzBuild/Debug/ch will be the JavaScript shell for the fuzzer

--- a/Targets/ChakraCore/chakracore.patch
+++ b/Targets/ChakraCore/chakracore.patch
@@ -1,0 +1,383 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 750292f30..985a2b61d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -507,6 +507,9 @@ if (CLANG_SANITIZE_SH)
+     unset(CLANG_SANITIZE_SH CACHE)      # don't cache
+ endif()
+ 
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-coverage=trace-pc-guard")
++set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fsanitize-coverage=trace-pc-guard")
++
+ add_subdirectory (pal)
+ 
+ # build the rest with NO_PAL_MINMAX and PAL_STDCPP_COMPAT
+diff --git a/bin/ch/WScriptJsrt.h b/bin/ch/WScriptJsrt.h
+index dc4bb49c6..374072a5e 100644
+--- a/bin/ch/WScriptJsrt.h
++++ b/bin/ch/WScriptJsrt.h
+@@ -109,6 +109,9 @@ class WScriptJsrt
+     static bool InstallObjectsOnObject(JsValueRef object, const char* name, JsNativeFunction nativeFunction);
+     static void FinalizeFree(void * addr);
+     static void RegisterScriptDir(DWORD_PTR sourceContext, LPCSTR fullDirNarrow);
++    static JsValueRef CALLBACK CrashCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
++    static JsValueRef CALLBACK FuzzoutCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
++    static MessageQueue *messageQueue;
+ private:
+     static void SetExceptionIf(JsErrorCode errorCode, LPCWSTR errorMessage);
+     static bool CreateArgumentsObject(JsValueRef *argsObject);
+@@ -150,7 +153,6 @@ class WScriptJsrt
+ 
+     static JsErrorCode FetchImportedModuleHelper(JsModuleRecord referencingModule, JsValueRef specifier, __out JsModuleRecord* dependentModuleRecord, LPCSTR refdir = nullptr);
+ 
+-    static MessageQueue *messageQueue;
+     static DWORD_PTR sourceContext;
+     static std::map<std::string, JsModuleRecord> moduleRecordMap;
+     static std::map<JsModuleRecord, std::string> moduleDirMap;
+diff --git a/bin/ch/ch.cpp b/bin/ch/ch.cpp
+index 5b8905b3c..216a69cf9 100644
+--- a/bin/ch/ch.cpp
++++ b/bin/ch/ch.cpp
+@@ -18,6 +18,199 @@
+ #include <sys/sysctl.h>
+ #endif
+ 
++//
++// BEGIN FUZZING CODE
++//
++
++#pragma push_macro("stderr")
++#pragma push_macro("puts")
++#pragma push_macro("malloc")
++#pragma push_macro("getenv")
++#pragma push_macro("printf")
++#pragma push_macro("fprintf")
++#pragma push_macro("errno")
++
++#undef stderr
++#undef puts
++#undef malloc
++#undef getenv
++#undef printf
++#undef fprintf
++#define errno (*__errno_location ())
++
++#include <fcntl.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <string.h>
++#include <sys/wait.h>
++#include <sys/mman.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++
++
++#define REPRL_CRFD 100
++#define REPRL_CWFD 101
++#define REPRL_DRFD 102
++#define REPRL_DWFD 103
++
++#define SHM_SIZE 0x100000
++#define MAX_EDGES ((SHM_SIZE - 4) * 8)
++
++#define CHECK(cond) if (!(cond)) { fprintf(stderr, "\"" #cond "\" failed\n"); _exit(-1); }
++
++struct shmem_data {
++    uint32_t num_edges;
++    unsigned char edges[];
++};
++
++struct shmem_data* __shmem;
++
++uint32_t *__edges_start, *__edges_stop;
++void __sanitizer_cov_reset_edgeguards() {
++    uint64_t N = 0;
++    for (uint32_t *x = __edges_start; x < __edges_stop && N < MAX_EDGES; x++)
++        *x = ++N;
++}
++
++extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop) {
++    // Avoid duplicate initialization
++    if (start == stop || *start)
++        return;
++
++    if (__edges_start != NULL || __edges_stop != NULL) {
++        fprintf(stderr, "Coverage instrumentation is only supported for a single module\n");
++        _exit(-1);
++    }
++
++    __edges_start = start;
++    __edges_stop = stop;
++
++    // Map the shared memory region
++
++    const char* shm_key = getenv("SHM_ID");
++
++    if (!shm_key) {
++        puts("[COV] no shared memory bitmap available, skipping");
++        __shmem = (struct shmem_data*) malloc(SHM_SIZE);
++    } else {
++        int fd = shm_open(shm_key, O_RDWR, S_IREAD | S_IWRITE);
++        if (fd <= -1) {
++            fprintf(stderr, "Failed to open shared memory region: %s\n", strerror(errno));
++            _exit(-1);
++        }
++
++        __shmem = (struct shmem_data*) mmap(0, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
++        if (__shmem == MAP_FAILED) {
++            fprintf(stderr, "Failed to mmap shared memory region\n");
++            _exit(-1);
++        }
++    }
++
++    __sanitizer_cov_reset_edgeguards();
++
++    __shmem->num_edges = stop - start;
++    printf("[COV] edge counters initialized. Shared memory: %s with %u edges\n", shm_key, __shmem->num_edges);
++}
++
++extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
++    uint32_t index = *guard;
++    if (!index) return;
++    index--;
++    __shmem->edges[index / 8] |= 1 << (index % 8);
++    *guard = 0;
++}
++
++#pragma pop_macro("errno")
++#pragma pop_macro("fprintf")
++#pragma pop_macro("printf")
++#pragma pop_macro("getenv")
++#pragma pop_macro("malloc")
++#pragma pop_macro("puts")
++#pragma pop_macro("stderr")
++
++
++FILE* fuzzout;
++bool reprl_mode = false;
++
++JsValueRef __stdcall WScriptJsrt::CrashCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState)
++{
++    if (argumentCount > 1)
++    {
++        int type = 0;
++        double typeDouble;
++        IfJsrtErrorFail(ChakraRTInterface::JsNumberToDouble(arguments[1], &typeDouble), JS_INVALID_REFERENCE);
++        type = (int)typeDouble;
++        switch (type) {
++            case 0:
++                *((int*)0x41414141) = 0x1337;
++                break;
++            case 1:
++                Assert(0);
++                break;
++            case 2:
++                Assert(0);
++                break;
++        }
++    }
++}
++
++JsValueRef __stdcall WScriptJsrt::FuzzoutCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState)
++{
++    for (unsigned int i = 1; i < argumentCount; i++)
++    {
++        JsValueRef strValue;
++        JsErrorCode error = ChakraRTInterface::JsConvertValueToString(arguments[i], &strValue);
++        if (error == JsNoError)
++        {
++            AutoString str(strValue);
++            if (str.GetError() == JsNoError)
++            {
++                if (i > 1)
++                {
++                    fwprintf(fuzzout, _u(" "));
++                }
++                charcount_t len;
++                LPWSTR ws = str.GetWideString(&len);
++                LPWSTR wsNoNull = new WCHAR[((size_t)len) + 1];
++                charcount_t newIndex = 0;
++                for (charcount_t j = 0; j < len; j++)
++                {
++                    if (ws[j] != _u('\0'))
++                    {
++                        wsNoNull[newIndex++] = ws[j];
++                    }
++                }
++                wsNoNull[newIndex] = _u('\0');
++                fwprintf(fuzzout, _u("%s"), wsNoNull);
++                delete[] wsNoNull;
++            }
++        }
++
++        if (error == JsErrorScriptException)
++        {
++            return nullptr;
++        }
++    }
++
++    fwprintf(fuzzout, _u("\n"));
++    fflush(fuzzout);
++
++    JsValueRef undefinedValue;
++    if (ChakraRTInterface::JsGetUndefinedValue(&undefinedValue) == JsNoError)
++    {
++        return undefinedValue;
++    }
++    else
++    {
++        return nullptr;
++    }
++}
++
++//
++// END FUZZING CODE
++//
++
+ unsigned int MessageBase::s_messageCount = 0;
+ Debugger* Debugger::debugger = nullptr;
+ 
+@@ -510,6 +703,7 @@ HRESULT RunScript(const char* fileName, LPCSTR fileContents, size_t fileLength,
+         if(runScript != JsNoError)
+         {
+             WScriptJsrt::PrintException(fileName, runScript);
++            hr = runScript;
+         }
+         else
+         {
+@@ -552,7 +746,9 @@ HRESULT RunScript(const char* fileName, LPCSTR fileContents, size_t fileLength,
+     }
+ 
+     // We only call RunScript() once, safe to Uninitialize()
+-    WScriptJsrt::Uninitialize();
++    if (!reprl_mode) {
++        WScriptJsrt::Uninitialize();
++    }
+ 
+     return hr;
+ }
+@@ -846,11 +1042,12 @@ HRESULT ExecuteTest(const char* fileName)
+ 
+         char fullPath[_MAX_PATH];
+         size_t len = 0;
++        if (!reprl_mode) {
++            hr = Helpers::LoadScriptFromFile(fileName, fileContents, &lengthBytes);
++            contentsRaw; lengthBytes; // Unused for now.
+ 
+-        hr = Helpers::LoadScriptFromFile(fileName, fileContents, &lengthBytes);
+-        contentsRaw; lengthBytes; // Unused for now.
+-
+-        IfFailGo(hr);
++            IfFailGo(hr);
++        }
+         if (HostConfigFlags::flags.GenerateLibraryByteCodeHeaderIsEnabled)
+         {
+             jsrtAttributes = (JsRuntimeAttributes)(jsrtAttributes | JsRuntimeAttributeSerializeLibraryByteCode);
+@@ -918,6 +1115,11 @@ HRESULT ExecuteTest(const char* fileName)
+         {
+             IfFailGo(E_FAIL);
+         }
++        JsValueRef global;
++        IfJsrtErrorFail(ChakraRTInterface::JsGetGlobalObject(&global), false);
++        IfFalseGo(WScriptJsrt::InstallObjectsOnObject(global, "crash", WScriptJsrt::CrashCallback));
++        IfFalseGo(WScriptJsrt::InstallObjectsOnObject(global, "__fuzzout__",  WScriptJsrt::FuzzoutCallback));
++
+ 
+         if (_fullpath(fullPath, fileName, _MAX_PATH) == nullptr)
+         {
+@@ -960,7 +1162,41 @@ HRESULT ExecuteTest(const char* fileName)
+         }
+         else
+         {
+-            IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, fullPath, nullptr));
++            do {
++                if (reprl_mode) {
++                    unsigned action = 0;
++                    ssize_t nread = read(REPRL_CRFD, &action, 4);
++                    if (nread != 4 || action != 'cexe') {
++                        fprintf(stderr, "Unknown action: %u\n", action);
++                        _exit(-1);
++                    }
++                    size_t script_size;
++                    Assert(read(REPRL_CRFD, &script_size, 8) == 8);
++                    char* buffer = new char[script_size + 1];
++                    char* ptr = buffer;
++                    size_t remaining = script_size;
++                    while (remaining > 0) {
++                        ssize_t rv = read(REPRL_DRFD, ptr, remaining);
++                        Assert(rv >= 0);
++                        remaining -= rv;
++                        ptr += rv;
++                    }
++                    buffer[script_size] = 0;
++                    fileContents = buffer;
++                    lengthBytes = script_size;
++
++                    WScriptJsrt::messageQueue = nullptr;
++                }
++                hr = RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, fullPath, nullptr);
++                if (reprl_mode) {
++                    int status = hr << 8;
++                    CHECK(write(REPRL_CWFD, &status, 4) == 4);
++                    __sanitizer_cov_reset_edgeguards();
++                }
++            }
++            while (reprl_mode);
++
++            IfFailGo(hr);
+         }
+     }
+ Error:
+@@ -1011,7 +1247,7 @@ HRESULT ExecuteTestWithMemoryCheck(char* fileName)
+ #else
+     // REVIEW: Do we need a SEH handler here?
+     hr = ExecuteTest(fileName);
+-    if (FAILED(hr)) exit(0);
++    if (FAILED(hr)) exit(-1);
+ #endif // _WIN32
+ 
+     _flushall();
+@@ -1148,6 +1384,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
+     int cpos = 1;
+     HINSTANCE chakraLibrary = nullptr;
+     bool success = false;
++
+     ChakraRTInterface::ArgInfo argInfo;
+ #ifdef _WIN32
+     ATOM lock;
+@@ -1241,6 +1478,10 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
+             LPCWSTR startEventStr = argv[i] + wcslen(_u("-TTDStartEvent="));
+             startEventCount = (UINT32)_wtoi(startEventStr);
+         }
++        else if(wcsstr(argv[i], _u("-reprl")) == argv[i])
++        {
++            reprl_mode = true;
++        }
+         else
+         {
+             wchar *temp = argv[cpos];
+@@ -1317,6 +1558,23 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
+         }
+ #else
+         // On linux, execute on the same thread
++        if (reprl_mode) {
++            // REPRL: let parent know we are ready
++            char helo[] = "HELO";
++            if (write(REPRL_CWFD, helo, 4) != 4 ||
++                read(REPRL_CRFD, helo, 4) != 4) {
++                reprl_mode = false;
++            }
++
++            if (memcmp(helo, "HELO", 4) != 0) {
++                fprintf(stderr, "Invalid response from parent\n");
++                _exit(-1);
++            }
++        }
++        fuzzout = _fdopen(REPRL_DWFD, "w");
++        if (!fuzzout)
++            fuzzout = stdout;
++
+         exitCode = ExecuteTestWithMemoryCheck(argInfo.filename);
+ #endif
+ 

--- a/Targets/ChakraCore/fuzzbuild.sh
+++ b/Targets/ChakraCore/fuzzbuild.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+./build.sh --target-path=FuzzBuild --debug --static -j


### PR DESCRIPTION
Based on the other targets with a couple of changes to ChakraCore to allow for reprl mode.

Not sure what the best options to `ch` are, so picked some that a few of the chakra test cases use but may need to be tweaked.

The `Execs / Second` is pretty low and a higher timeout is required, there might be a few more changed that could be make to the patch to speed this up