### PR TITLE
If importing the state fails, fall back to importing the corpus

### DIFF
--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -244,8 +244,8 @@ public class Fuzzer {
     ///
     /// If importing fails, this method will throw a Fuzzilli.RuntimeError.
     public func importState(_ state: State) throws {
-        try corpus.importState(state.corpus)
         try evaluator.importState(state.evaluatorState)
+        try corpus.importState(state.corpus)
     }
     
     /// Executes a program.

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -215,7 +215,12 @@ fuzzer.queue.addOperation {
             let decoder = JSONDecoder()
             let data = try Data(contentsOf: URL(fileURLWithPath: path))
             let state = try decoder.decode(Fuzzer.State.self, from: data)
-            try fuzzer.importState(state)
+            do {
+                try fuzzer.importState(state)
+            } catch is RuntimeError {
+                logger.warning("Could not import state, falling back to corpus import")
+                fuzzer.importCorpus(state.corpus);
+            }
             logger.info("Successfully imported previous state. Corpus now contains \(fuzzer.corpus.size) elements")
         } catch {
             logger.fatal("Failed to import state: \(error.localizedDescription)")


### PR DESCRIPTION
Fixes https://github.com/googleprojectzero/fuzzilli/issues/27

I think swapping https://github.com/googleprojectzero/fuzzilli/compare/master...wbowling:fallback-to-corpus-import?expand=1#diff-c16198c482fd89831fdde8be546741a8R248 should remove the need to reset any state on a failed import?