### PR TITLE
fixed typo in JS Environment builtins

### DIFF
--- a/Sources/Fuzzilli/Core/JavaScriptEnvironment.swift
+++ b/Sources/Fuzzilli/Core/JavaScriptEnvironment.swift
@@ -144,7 +144,7 @@ public class JavaScriptEnvironment: ComponentBase, Environment {
         
         // Register pseudo builtins
         registerBuiltin("this", ofType: .object())
-        registerBuiltin("argumets", ofType: .object())
+        registerBuiltin("arguments", ofType: .object())
         
         for (builtin, type) in additionalBuiltins {
             registerBuiltin(builtin, ofType: type)


### PR DESCRIPTION
fixes a minor typo when registering JS Environment builtins.