### PR TITLE
Update JSC patch to support new HostFunction signature

### DIFF
--- a/Targets/JavaScriptCore/README.md
+++ b/Targets/JavaScriptCore/README.md
@@ -3,6 +3,6 @@
 To build JavaScriptCore (jsc) for fuzzing:
 
 1. Clone the WebKit mirror from https://github.com/WebKit/webkit
-2. Apply webkit.patch. The patch should apply cleanly to git commit d6913c0043553080fa46caa49041e0b137db38a1
+2. Apply webkit.patch. The patch should apply cleanly to git commit c25f028e88f8f7365b75d7f2fd90f40a04d1d3fa
 3. Run the fuzzbuild.sh script in the webkit root directory
 4. FuzzBuild/Debug/bin/jsc will be the JavaScript shell for the fuzzer

--- a/Targets/JavaScriptCore/webkit.patch
+++ b/Targets/JavaScriptCore/webkit.patch
@@ -1,8 +1,8 @@
 diff --git a/Source/JavaScriptCore/jsc.cpp b/Source/JavaScriptCore/jsc.cpp
-index ead01e20b7a..93345b71a32 100644
+index 024a83ed25f..31870060c92 100644
 --- a/Source/JavaScriptCore/jsc.cpp
 +++ b/Source/JavaScriptCore/jsc.cpp
-@@ -158,6 +158,89 @@ struct MemoryFootprint {
+@@ -170,6 +170,89 @@ struct MemoryFootprint {
  #if !defined(PATH_MAX)
  #define PATH_MAX 4096
  #endif
@@ -92,26 +92,26 @@ index ead01e20b7a..93345b71a32 100644
  
  using namespace JSC;
  
-@@ -377,6 +460,7 @@ static EncodedJSValue JSC_HOST_CALL functionFlashHeapAccess(ExecState*);
- static EncodedJSValue JSC_HOST_CALL functionDisableRichSourceInfo(ExecState*);
- static EncodedJSValue JSC_HOST_CALL functionMallocInALoop(ExecState*);
- static EncodedJSValue JSC_HOST_CALL functionTotalCompileTime(ExecState*);
-+static EncodedJSValue JSC_HOST_CALL functionFuzzilli(ExecState* exec);
+@@ -388,6 +471,7 @@ static EncodedJSValue JSC_HOST_CALL functionFlashHeapAccess(JSGlobalObject*, Cal
+ static EncodedJSValue JSC_HOST_CALL functionDisableRichSourceInfo(JSGlobalObject*, CallFrame*);
+ static EncodedJSValue JSC_HOST_CALL functionMallocInALoop(JSGlobalObject*, CallFrame*);
+ static EncodedJSValue JSC_HOST_CALL functionTotalCompileTime(JSGlobalObject*, CallFrame*);
++static EncodedJSValue JSC_HOST_CALL functionFuzzilli(JSGlobalObject*, CallFrame*);
  
- struct Script {
-     enum class StrictMode {
-@@ -632,6 +716,8 @@ protected:
-         addFunction(vm, "disableRichSourceInfo", functionDisableRichSourceInfo, 0);
-         addFunction(vm, "mallocInALoop", functionMallocInALoop, 0);
+ static EncodedJSValue JSC_HOST_CALL functionSetUnhandledRejectionCallback(JSGlobalObject*, CallFrame*);
+ 
+@@ -647,6 +731,8 @@ protected:
          addFunction(vm, "totalCompileTime", functionTotalCompileTime, 0);
+ 
+         addFunction(vm, "setUnhandledRejectionCallback", functionSetUnhandledRejectionCallback, 1);
 +
 +        addFunction(vm, "fuzzilli", functionFuzzilli, 2);
      }
      
      void addFunction(VM& vm, JSObject* object, const char* name, NativeFunction function, unsigned arguments)
-@@ -1260,6 +1346,55 @@ fail:
- EncodedJSValue JSC_HOST_CALL functionPrintStdOut(ExecState* exec) { return printInternal(exec, stdout); }
- EncodedJSValue JSC_HOST_CALL functionPrintStdErr(ExecState* exec) { return printInternal(exec, stderr); }
+@@ -1276,6 +1362,55 @@ fail:
+ EncodedJSValue JSC_HOST_CALL functionPrintStdOut(JSGlobalObject*, CallFrame* callFrame) { return printInternal(callFrame, stdout); }
+ EncodedJSValue JSC_HOST_CALL functionPrintStdErr(JSGlobalObject*, CallFrame* callFrame) { return printInternal(callFrame, stderr); }
  
 +// We have to assume that the fuzzer will be able to call this function e.g. by
 +// enumerating the properties of the global object and eval'ing them. As such
@@ -119,19 +119,19 @@ index ead01e20b7a..93345b71a32 100644
 +// as first argument (with the idea being that the fuzzer won't be able to
 +// generate this value) which then also acts as a selector for the operation
 +// to perform.
-+EncodedJSValue JSC_HOST_CALL functionFuzzilli(ExecState* exec)
++EncodedJSValue JSC_HOST_CALL functionFuzzilli(JSGlobalObject* globalObject, CallFrame* callFrame)
 +{
-+    VM& vm = exec->vm();
++    VM& vm = globalObject->vm();
 +    auto scope = DECLARE_THROW_SCOPE(vm);
-+    if (!exec->argument(0).isString()) {
++    if (!callFrame->argument(0).isString()) {
 +        // We directly require a string as argument for simplicity
 +        return JSValue::encode(jsUndefined());
 +    }
-+    auto operation = exec->argument(0).toString(exec)->value(exec);
++    auto operation = callFrame->argument(0).toString(callFrame)->value(callFrame);
 +    RETURN_IF_EXCEPTION(scope, encodedJSValue());
 +
 +    if (operation == "FUZZILLI_CRASH") {
-+        auto arg = exec->argument(1).toInt32(exec);
++        auto arg = callFrame->argument(1).toInt32(callFrame);
 +        RETURN_IF_EXCEPTION(scope, encodedJSValue());
 +        switch (arg) {
 +            case 0:
@@ -151,9 +151,9 @@ index ead01e20b7a..93345b71a32 100644
 +            fzliout = stdout;
 +        }
 +
-+        auto viewWithString = exec->argument(1).toString(exec)->viewWithUnderlyingString(exec);
++        auto viewWithString = callFrame->argument(1).toString(callFrame)->viewWithUnderlyingString(callFrame);
 +        RETURN_IF_EXCEPTION(scope, encodedJSValue());
-+        auto string = cStringFromViewWithString(exec, scope, viewWithString);
++        auto string = cStringFromViewWithString(callFrame, scope, viewWithString);
 +        RETURN_IF_EXCEPTION(scope, encodedJSValue());
 +        fprintf(fzliout, "%s\n", string.data());
 +        fflush(fzliout);
@@ -162,10 +162,10 @@ index ead01e20b7a..93345b71a32 100644
 +    return JSValue::encode(jsUndefined());
 +}
 +
- EncodedJSValue JSC_HOST_CALL functionDebug(ExecState* exec)
+ EncodedJSValue JSC_HOST_CALL functionDebug(JSGlobalObject* globalObject, CallFrame* callFrame)
  {
-     VM& vm = exec->vm();
-@@ -1881,7 +2016,7 @@ EncodedJSValue JSC_HOST_CALL functionDollarAgentStart(ExecState* exec)
+     VM& vm = globalObject->vm();
+@@ -1903,7 +2038,7 @@ EncodedJSValue JSC_HOST_CALL functionDollarAgentStart(JSGlobalObject* globalObje
              commandLine.m_interactive = false;
              runJSC(
                  commandLine, true,
@@ -174,7 +174,7 @@ index ead01e20b7a..93345b71a32 100644
                      // Notify the thread that started us that we have registered a worker.
                      {
                          auto locker = holdLock(didStartLock);
-@@ -2575,7 +2710,7 @@ static void checkException(ExecState* exec, GlobalObject* globalObject, bool isL
+@@ -2610,7 +2745,7 @@ static void checkException(ExecState* exec, GlobalObject* globalObject, bool isL
          success = success && checkUncaughtException(vm, globalObject, (hasException) ? value : JSValue(), options);
  }
  
@@ -183,7 +183,7 @@ index ead01e20b7a..93345b71a32 100644
  {
      Vector<Script>& scripts = options.m_scripts;
      String fileName;
-@@ -2594,7 +2729,21 @@ static void runWithOptions(GlobalObject* globalObject, CommandLine& options, boo
+@@ -2626,7 +2761,21 @@ static void runWithOptions(GlobalObject* globalObject, CommandLine& options, boo
      for (size_t i = 0; i < scripts.size(); i++) {
          JSInternalPromise* promise = nullptr;
          bool isModule = options.m_module || scripts[i].scriptType == Script::ScriptType::Module;
@@ -206,7 +206,7 @@ index ead01e20b7a..93345b71a32 100644
              fileName = scripts[i].argument;
              if (scripts[i].strictMode == Script::StrictMode::Strict)
                  scriptBuffer.append("\"use strict\";\n", strlen("\"use strict\";\n"));
-@@ -2957,7 +3106,40 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
+@@ -2989,7 +3138,40 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
      
      VM& vm = VM::create(LargeHeap).leakRef();
      int result;
@@ -248,7 +248,7 @@ index ead01e20b7a..93345b71a32 100644
      GlobalObject* globalObject = nullptr;
      {
          JSLockHolder locker(vm);
-@@ -2967,7 +3149,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
+@@ -2999,7 +3181,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
  
          globalObject = GlobalObject::create(vm, GlobalObject::createStructure(vm, jsNull()), options.m_arguments);
          globalObject->setRemoteDebuggingEnabled(options.m_enableRemoteDebugging);
@@ -257,7 +257,7 @@ index ead01e20b7a..93345b71a32 100644
          vm.drainMicrotasks();
      }
      vm.promiseDeferredTimer->runRunLoop();
-@@ -2979,59 +3161,18 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
+@@ -3011,59 +3193,18 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
  
      result = success && (asyncTestExpectedPasses == asyncTestPasses) ? 0 : 3;
  
@@ -322,7 +322,7 @@ index ead01e20b7a..93345b71a32 100644
  
      vm.codeCache()->write(vm);
  
-@@ -3101,15 +3242,15 @@ int jscmain(int argc, char** argv)
+@@ -3145,15 +3286,15 @@ int jscmain(int argc, char** argv)
          }
      };
  #endif


### PR DESCRIPTION
Webkit commit 622e869db55d9e78435fe55ea11007d0639ff44e updates the HostFunction signature from (ExecState*) to (JSGlobalObject*, CallFrame*). This PR updates fuzzilli's JSC patch to support this change.

The target README was also updated to list the latest webkit commit the patch was tested on.