### PR TITLE
Support new JSC compilation mode

### DIFF
--- a/Targets/JavaScriptCore/fuzzbuild.sh
+++ b/Targets/JavaScriptCore/fuzzbuild.sh
@@ -17,10 +17,10 @@
 export WEBKIT_OUTPUTDIR=FuzzBuild
 
 if [ "$(uname)" == "Darwin" ]; then
-    ./Tools/Scripts/build-jsc --jsc-only --debug --cmakeargs="-DENABLE_STATIC_JSC=ON -DCMAKE_CXX_FLAGS='-fsanitize-coverage=trace-pc-guard -O3'"
+    ./Tools/Scripts/build-jsc --jsc-only --release-and-assert --cmakeargs="-DENABLE_STATIC_JSC=ON -DCMAKE_CXX_FLAGS='-fsanitize-coverage=trace-pc-guard -DASSERT_ENABLED=1'"
 elif [ "$(uname)" == "Linux" ]; then
     # Note: requires clang >= 4.0!
-    ./Tools/Scripts/build-jsc --jsc-only --debug --cmakeargs="-DENABLE_STATIC_JSC=ON -DCMAKE_C_COMPILER='/usr/bin/clang' -DCMAKE_CXX_COMPILER='/usr/bin/clang++' -DCMAKE_CXX_FLAGS='-fsanitize-coverage=trace-pc-guard -O3 -lrt'"
+    ./Tools/Scripts/build-jsc --jsc-only --release-and-assert --cmakeargs="-DENABLE_STATIC_JSC=ON -DCMAKE_C_COMPILER='/usr/bin/clang' -DCMAKE_CXX_COMPILER='/usr/bin/clang++' -DCMAKE_CXX_FLAGS='-fsanitize-coverage=trace-pc-guard -lrt -DASSERT_ENABLED=1'"
 else
     echo "Unsupported operating system"
 fi

--- a/Targets/JavaScriptCore/webkit.patch
+++ b/Targets/JavaScriptCore/webkit.patch
@@ -1,8 +1,8 @@
 diff --git a/Source/JavaScriptCore/jsc.cpp b/Source/JavaScriptCore/jsc.cpp
-index 024a83ed25f..31870060c92 100644
+index 702f8df3c47..c892b534a9f 100644
 --- a/Source/JavaScriptCore/jsc.cpp
 +++ b/Source/JavaScriptCore/jsc.cpp
-@@ -170,6 +170,89 @@ struct MemoryFootprint {
+@@ -173,6 +173,89 @@ struct MemoryFootprint {
  #if !defined(PATH_MAX)
  #define PATH_MAX 4096
  #endif
@@ -92,7 +92,7 @@ index 024a83ed25f..31870060c92 100644
  
  using namespace JSC;
  
-@@ -388,6 +471,7 @@ static EncodedJSValue JSC_HOST_CALL functionFlashHeapAccess(JSGlobalObject*, Cal
+@@ -397,6 +480,7 @@ static EncodedJSValue JSC_HOST_CALL functionFlashHeapAccess(JSGlobalObject*, Cal
  static EncodedJSValue JSC_HOST_CALL functionDisableRichSourceInfo(JSGlobalObject*, CallFrame*);
  static EncodedJSValue JSC_HOST_CALL functionMallocInALoop(JSGlobalObject*, CallFrame*);
  static EncodedJSValue JSC_HOST_CALL functionTotalCompileTime(JSGlobalObject*, CallFrame*);
@@ -100,7 +100,7 @@ index 024a83ed25f..31870060c92 100644
  
  static EncodedJSValue JSC_HOST_CALL functionSetUnhandledRejectionCallback(JSGlobalObject*, CallFrame*);
  
-@@ -647,6 +731,8 @@ protected:
+@@ -654,6 +738,8 @@ protected:
          addFunction(vm, "totalCompileTime", functionTotalCompileTime, 0);
  
          addFunction(vm, "setUnhandledRejectionCallback", functionSetUnhandledRejectionCallback, 1);
@@ -109,9 +109,9 @@ index 024a83ed25f..31870060c92 100644
      }
      
      void addFunction(VM& vm, JSObject* object, const char* name, NativeFunction function, unsigned arguments)
-@@ -1276,6 +1362,55 @@ fail:
- EncodedJSValue JSC_HOST_CALL functionPrintStdOut(JSGlobalObject*, CallFrame* callFrame) { return printInternal(callFrame, stdout); }
- EncodedJSValue JSC_HOST_CALL functionPrintStdErr(JSGlobalObject*, CallFrame* callFrame) { return printInternal(callFrame, stderr); }
+@@ -1282,6 +1368,55 @@ fail:
+ EncodedJSValue JSC_HOST_CALL functionPrintStdOut(JSGlobalObject* globalObject, CallFrame* callFrame) { return printInternal(globalObject, callFrame, stdout); }
+ EncodedJSValue JSC_HOST_CALL functionPrintStdErr(JSGlobalObject* globalObject, CallFrame* callFrame) { return printInternal(globalObject, callFrame, stderr); }
  
 +// We have to assume that the fuzzer will be able to call this function e.g. by
 +// enumerating the properties of the global object and eval'ing them. As such
@@ -165,7 +165,7 @@ index 024a83ed25f..31870060c92 100644
  EncodedJSValue JSC_HOST_CALL functionDebug(JSGlobalObject* globalObject, CallFrame* callFrame)
  {
      VM& vm = globalObject->vm();
-@@ -1903,7 +2038,7 @@ EncodedJSValue JSC_HOST_CALL functionDollarAgentStart(JSGlobalObject* globalObje
+@@ -1919,7 +2054,7 @@ EncodedJSValue JSC_HOST_CALL functionDollarAgentStart(JSGlobalObject* globalObje
              commandLine.m_interactive = false;
              runJSC(
                  commandLine, true,
@@ -174,7 +174,7 @@ index 024a83ed25f..31870060c92 100644
                      // Notify the thread that started us that we have registered a worker.
                      {
                          auto locker = holdLock(didStartLock);
-@@ -2610,7 +2745,7 @@ static void checkException(ExecState* exec, GlobalObject* globalObject, bool isL
+@@ -2664,7 +2799,7 @@ static void checkException(GlobalObject* globalObject, bool isLastFile, bool has
          success = success && checkUncaughtException(vm, globalObject, (hasException) ? value : JSValue(), options);
  }
  
@@ -183,7 +183,7 @@ index 024a83ed25f..31870060c92 100644
  {
      Vector<Script>& scripts = options.m_scripts;
      String fileName;
-@@ -2626,7 +2761,21 @@ static void runWithOptions(GlobalObject* globalObject, CommandLine& options, boo
+@@ -2680,7 +2815,21 @@ static void runWithOptions(GlobalObject* globalObject, CommandLine& options, boo
      for (size_t i = 0; i < scripts.size(); i++) {
          JSInternalPromise* promise = nullptr;
          bool isModule = options.m_module || scripts[i].scriptType == Script::ScriptType::Module;
@@ -206,7 +206,7 @@ index 024a83ed25f..31870060c92 100644
              fileName = scripts[i].argument;
              if (scripts[i].strictMode == Script::StrictMode::Strict)
                  scriptBuffer.append("\"use strict\";\n", strlen("\"use strict\";\n"));
-@@ -2989,7 +3138,40 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
+@@ -3051,7 +3200,40 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
      
      VM& vm = VM::create(LargeHeap).leakRef();
      int result;
@@ -248,7 +248,7 @@ index 024a83ed25f..31870060c92 100644
      GlobalObject* globalObject = nullptr;
      {
          JSLockHolder locker(vm);
-@@ -2999,7 +3181,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
+@@ -3062,7 +3244,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
  
          globalObject = GlobalObject::create(vm, GlobalObject::createStructure(vm, jsNull()), options.m_arguments);
          globalObject->setRemoteDebuggingEnabled(options.m_enableRemoteDebugging);
@@ -256,8 +256,8 @@ index 024a83ed25f..31870060c92 100644
 +        func(vm, globalObject, success, fd, script_size);
          vm.drainMicrotasks();
      }
-     vm.promiseDeferredTimer->runRunLoop();
-@@ -3011,59 +3193,18 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
+     vm.promiseTimer->runRunLoop();
+@@ -3074,63 +3256,19 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
  
      result = success && (asyncTestExpectedPasses == asyncTestPasses) ? 0 : 3;
  
@@ -296,6 +296,9 @@ index 024a83ed25f..31870060c92 100644
 -        std::sort(compileTimeKeys.begin(), compileTimeKeys.end());
 -        for (const CString& key : compileTimeKeys)
 -            printf("%40s: %.3lf ms\n", key.data(), compileTimeStats.get(key).milliseconds());
+-
+-        if (Options::reportTotalPhaseTimes())
+-            logTotalPhaseTimes();
 -    }
 -#endif
 -
@@ -313,16 +316,19 @@ index 024a83ed25f..31870060c92 100644
 -#else
 -        dataLog("Sampling profiler is not enabled on this platform\n");
 -#endif
+-    }
+-
 +    if (reprl_mode) {
 +        int status = result << 8;
 +        CHECK(write(REPRL_CWFD, &status, 4) == 4);
 +        __sanitizer_cov_reset_edgeguards();
-     }
++     }
 +    } while (reprl_mode);
- 
++   
      vm.codeCache()->write(vm);
  
-@@ -3145,15 +3286,15 @@ int jscmain(int argc, char** argv)
+     if (options.m_destroyVM || isWorker) {
+@@ -3211,15 +3349,15 @@ int jscmain(int argc, char** argv)
          }
      };
  #endif


### PR DESCRIPTION
Added support for release+assert compilation mode. Reference: #58 
Release builds use O3 optimisation by default and so we don't need to add the optimisation flag to our build script.

I've also looked into generating debug builds with forced optimisation but that isn't any different from what we've currently got in the build script.

I haven't tested this on macOS, but I don't see the flags being too dissimilar. If someone could run a quick build on macOS and post their results here, that would be bril. 