### PR TITLE
Fix race condition in sanitizer coverage

### DIFF
--- a/Targets/JavaScriptCore/webkit.patch
+++ b/Targets/JavaScriptCore/webkit.patch
@@ -80,9 +80,8 @@ index 024a83ed25f..31870060c92 100644
 +}
 +
 +extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
-+    if (!*guard) return;
 +    uint32_t index = *guard - 1;
-+    if (index == -1) return;
++    if (index == -1) return;      // Edge has already been discovered
 +    __shmem->edges[index / 8] |= 1 << (index % 8);
 +    *guard = 0;
 +}

--- a/Targets/JavaScriptCore/webkit.patch
+++ b/Targets/JavaScriptCore/webkit.patch
@@ -82,6 +82,7 @@ index 024a83ed25f..31870060c92 100644
 +extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
 +    if (!*guard) return;
 +    uint32_t index = *guard - 1;
++    if (index == -1) return;
 +    __shmem->edges[index / 8] |= 1 << (index % 8);
 +    *guard = 0;
 +}

--- a/Targets/Spidermonkey/firefox.patch
+++ b/Targets/Spidermonkey/firefox.patch
@@ -73,9 +73,8 @@ index f93938a4ba03..b527e01bf093 100644
 +}
 +
 +extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
-+    if (!*guard) return;
 +    uint32_t index = *guard - 1;
-+    if (index == -1) return;
++    if (index == -1) return;      // Edge has already been discovered
 +    __shmem->edges[index / 8] |= 1 << (index % 8);
 +    *guard = 0;
 +}

--- a/Targets/Spidermonkey/firefox.patch
+++ b/Targets/Spidermonkey/firefox.patch
@@ -75,6 +75,7 @@ index f93938a4ba03..b527e01bf093 100644
 +extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
 +    if (!*guard) return;
 +    uint32_t index = *guard - 1;
++    if (index == -1) return;
 +    __shmem->edges[index / 8] |= 1 << (index % 8);
 +    *guard = 0;
 +}

--- a/Targets/V8/v8.patch
+++ b/Targets/V8/v8.patch
@@ -87,11 +87,10 @@ index 0000000000..8b5e9cf0ca
 +}
 +
 +extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
-+  if (!*guard) return;
 +  uint32_t index = *guard - 1;
-+  if (index == -1) return;
++  if (index == -1) return;      // Edge has already been discovered
 +  shmem->edges[index / 8] |= 1 << (index % 8);
-+  *guard = 0;                 // if multiple threads are active, this can lead to crashes due to race conditions
++  *guard = 0;
 +}
 diff --git a/src/d8/cov.h b/src/d8/cov.h
 new file mode 100644

--- a/Targets/V8/v8.patch
+++ b/Targets/V8/v8.patch
@@ -89,6 +89,7 @@ index 0000000000..8b5e9cf0ca
 +extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t *guard) {
 +  if (!*guard) return;
 +  uint32_t index = *guard - 1;
++  if (index == -1) return;
 +  shmem->edges[index / 8] |= 1 << (index % 8);
 +  *guard = 0;                 // if multiple threads are active, this can lead to crashes due to race conditions
 +}


### PR DESCRIPTION
I just added a small check to avoid crashes in `__sanitizer_cov_trace_pc_guard`. Although the race condition still happens but it will not lead to crashes.