### PR TITLE
Added ecmaversion to profiles

### DIFF
--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Supported versions of the ECMA standard.
+public enum ECMAScriptVersion {
+    case es5
+    case es6
+}
+
+
 /// Lifts a FuzzIL program to JavaScript.
 public class JavaScriptLifter: ComponentBase, Lifter {
     /// Prefix and suffix to surround the emitted code in
@@ -26,21 +33,20 @@ public class JavaScriptLifter: ComponentBase, Lifter {
     /// For node.js this is "global", otherwise probably just "this".
     let globalObjectIdentifier: String
     
-    /// Supported versions of the ECMA standard.
-    enum ECMAScriptVersion {
-        case es5
-        case es6
-    }
-    
+
     /// The version of the ECMAScript standard that this lifter generates code for.
     let version: ECMAScriptVersion
 
-    public init(prefix: String = "", suffix: String = "", inliningPolicy: InliningPolicy, globalObjectIdentifier: String = "this") {
+    public init(prefix: String = "",
+                suffix: String = "",
+                inliningPolicy: InliningPolicy,
+                globalObjectIdentifier: String = "this",
+                ecmaVersion: ECMAScriptVersion) {
         self.prefix = prefix
         self.suffix = suffix
         self.policy = inliningPolicy
         self.globalObjectIdentifier = globalObjectIdentifier
-        self.version = .es6
+        self.version = ecmaVersion
         
         super.init(name: "JavaScriptLifter")
     }

--- a/Sources/FuzzilliCli/Profiles/JSCProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/JSCProfile.swift
@@ -61,7 +61,9 @@ let jscProfile = Profile(
                 noFTL(main);
                 main();
                 """,
-    
+
+    ecmaVersion: ECMAScriptVersion.es6,
+
     crashTests: ["fuzzilli('FUZZILLI_CRASH', 0)", "fuzzilli('FUZZILLI_CRASH', 1)", "fuzzilli('FUZZILLI_CRASH', 2)"],
 
     additionalCodeGenerators: WeightedList<CodeGenerator>([

--- a/Sources/FuzzilliCli/Profiles/Profile.swift
+++ b/Sources/FuzzilliCli/Profiles/Profile.swift
@@ -19,7 +19,8 @@ struct Profile {
     var processEnv: [String : String]
     let codePrefix: String
     let codeSuffix: String
-    
+    let ecmaVersion: ECMAScriptVersion
+
     // JavaScript code snippets that cause a crash in the target engine.
     // Used to verify that crashes can be detected.
     let crashTests: [String]

--- a/Sources/FuzzilliCli/Profiles/SpidermonkeyProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/SpidermonkeyProfile.swift
@@ -51,6 +51,8 @@ let spidermonkeyProfile = Profile(
                 gc();
                 """,
 
+    ecmaVersion: ECMAScriptVersion.es6,
+
     crashTests: ["fuzzilli('FUZZILLI_CRASH', 0)", "fuzzilli('FUZZILLI_CRASH', 1)", "fuzzilli('FUZZILLI_CRASH', 2)"],
 
     additionalCodeGenerators: WeightedList<CodeGenerator>([

--- a/Sources/FuzzilliCli/Profiles/V8Profile.swift
+++ b/Sources/FuzzilliCli/Profiles/V8Profile.swift
@@ -48,7 +48,9 @@ let v8Profile = Profile(
                 %NeverOptimizeFunction(main);
                 main();
                 """,
-    
+
+    ecmaVersion: ECMAScriptVersion.es6,
+
     crashTests: ["fuzzilli('FUZZILLI_CRASH', 0)", "fuzzilli('FUZZILLI_CRASH', 1)", "fuzzilli('FUZZILLI_CRASH', 2)"],
     
     additionalCodeGenerators: WeightedList<CodeGenerator>([

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -165,7 +165,10 @@ let evaluator = ProgramCoverageEvaluator(runner: runner)
 let environment = JavaScriptEnvironment(additionalBuiltins: profile.additionalBuiltins, additionalObjectGroups: [])
 
 // A lifter to translate FuzzIL programs to JavaScript.
-let lifter = JavaScriptLifter(prefix: profile.codePrefix, suffix: profile.codeSuffix, inliningPolicy: InlineOnlyLiterals())
+let lifter = JavaScriptLifter(prefix: profile.codePrefix,
+                              suffix: profile.codeSuffix,
+                              inliningPolicy: InlineOnlyLiterals(),
+                              ecmaVersion: profile.ecmaVersion)
 
 // Corpus managing interesting programs that have been found during fuzzing.
 let corpus = Corpus(minSize: minCorpusSize, maxSize: maxCorpusSize, minMutationsPerSample: minMutationsPerSample)


### PR DESCRIPTION
Adds ECMAScript version as part of each profile. This is useful for engine targets outside the "big 3" already supported.

In sanity checking against V8, there is a significant performance degradation running it as es5 vs es6 (~4-5x in execs/second), which I believe is due to the additional scope overhead?