### PR TITLE
Added two duktape security bugs to the showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ The following is a list of some of the bugs found with the help of Fuzzilli. Onl
 * [CVE-2019-5853](https://bugs.chromium.org/p/chromium/issues/detail?id=976627): Memory corruption in regexp length check
 * [Issue 992914](https://bugs.chromium.org/p/project-zero/issues/detail?id=1923): Map migration doesn't respect element kinds, leading to type confusion
 
+#### [Duktape](https://github.com/svaarala/duktape)
+
+* [Issue 2323](https://github.com/svaarala/duktape/pull/2323): Unstable valstack pointer in putprop
+* [Issue 2320](https://github.com/svaarala/duktape/pull/2320): Memcmp pointer overflow in string builtin
+
 ## Disclaimer
 
 This is not an officially supported Google product.


### PR DESCRIPTION
Adds two security bugs found in duktape to the showcase.

Fuzzilli also found the following, which may or many not be security related:
- [Hash handling in enum sorting](https://github.com/svaarala/duktape/pull/2322/files)
- [Assertion failure in CBOR.decode](https://github.com/svaarala/duktape/issues/2316)