### PR TITLE
Fix for directory update in Duktape

### DIFF
--- a/Cloud/Docker/DuktapeBuilder/Dockerfile
+++ b/Cloud/Docker/DuktapeBuilder/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get -y update && apt-get -y upgrade
 # Assume that the current master branch maintains duk-fuzzilli
 # No need to patch, as the fuzz target is maintained in the duktape repo
 # Start building!
-RUN make duk-fuzzilli
+RUN make build/duk-fuzzilli

--- a/Cloud/Docker/DuktapeBuilder/build.sh
+++ b/Cloud/Docker/DuktapeBuilder/build.sh
@@ -16,7 +16,7 @@ docker build --build-arg rev=$REV -t duktape_builder .
 # Copy build products
 mkdir -p out
 docker create --name temp_container duktape_builder
-docker cp temp_container:/home/builder/duktape/duk-fuzzilli out/duk-fuzzilli
+docker cp temp_container:/home/builder/duktape/build/duk-fuzzilli out/duk-fuzzilli
 docker rm temp_container
 
 # Nothing extra to clean up!


### PR DESCRIPTION
Updates the Duktape docker container build process, due to changes in the directory structure of that project.