### PR TITLE
Added Template literals and EvalGenerator

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -39,6 +39,12 @@ public func StringLiteralGenerator(_ b: ProgramBuilder) {
     b.loadString(b.genString())
 }
 
+public func TemplateLiteralGenerator(_ b: ProgramBuilder) {
+    if !b.isInTemplate {
+        b.loadTemplate(b.genTemplate())
+    }
+}
+
 public func BooleanLiteralGenerator(_ b: ProgramBuilder) {
     b.loadBool(Bool.random())
 }
@@ -242,6 +248,14 @@ public func FunctionCallGenerator(_ b: ProgramBuilder) {
     let arguments = b.generateCallArguments(for: function)
     
     b.callFunction(function, withArgs: arguments)
+}
+
+public func EvalGenerator(_ b: ProgramBuilder) {
+    if !b.isInTemplate {
+        let eval = b.loadBuiltin("eval")
+        let template = b.loadTemplate(b.genTemplate())
+        b.callFunction(eval, withArgs: [template])
+    }
 }
 
 public func FunctionReturnGenerator(_ b: ProgramBuilder) {

--- a/Sources/Fuzzilli/Core/Environment.swift
+++ b/Sources/Fuzzilli/Core/Environment.swift
@@ -60,6 +60,9 @@ public protocol Environment: Component {
     /// The type representing strings in the target environment.
     var stringType: Type { get }
     
+    /// The type representing templates in the target environment
+    var templateType: Type { get }
+
     /// The type representing plain objects in the target environment.
     /// Used e.g. for objects created through a literal.
     var objectType: Type { get }

--- a/Sources/Fuzzilli/Core/JavaScriptEnvironment.swift
+++ b/Sources/Fuzzilli/Core/JavaScriptEnvironment.swift
@@ -49,6 +49,7 @@ public class JavaScriptEnvironment: ComponentBase, Environment {
     public var booleanType = Type.boolean
     public var regExpType = Type.jsRegExp
     public var stringType = Type.jsString
+    public var templateType = Type.jsTemplate
     public var arrayType = Type.jsArray
     public var objectType = Type.jsPlainObject
     
@@ -266,6 +267,9 @@ public extension Type {
     /// A JS string is both a string and an object on which methods can be called.
     static let jsString = Type.string + Type.object(ofGroup: "String", withProperties: ["__proto__", "constructor", "length"], withMethods: ["charAt", "charCodeAt", "codePointAt", "concat", "includes", "endsWith", "indexOf", "lastIndexOf", "match", "matchAll", "padEnd", "padStart", "repeat", "replace", "search", "slice", "split", "startsWith", "substring", "trim"])
     
+    /// A JS template is a string with embedded expressions
+    static let jsTemplate = Type.template
+
     /// Type of a regular expression in JavaScript.
     /// A JS RegExp is both a RegExp and an object on which methods can be called.
     static let jsRegExp = Type.regexp + Type.object(ofGroup: "RegExp", withProperties: ["__proto__", "flags", "dotAll", "global", "ignoreCase", "multiline", "source", "sticky", "unicode"], withMethods: ["compile", "exec", "test"])

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -203,6 +203,9 @@ public struct AbstractInterpreter {
             
         case is LoadString:
             set(instr.output, environment.stringType)
+
+        case is LoadTemplate:
+            set(instr.output, environment.templateType)
             
         case is LoadBoolean:
             set(instr.output, environment.booleanType)

--- a/Sources/Fuzzilli/FuzzIL/Analyzer.swift
+++ b/Sources/Fuzzilli/FuzzIL/Analyzer.swift
@@ -126,12 +126,18 @@ struct ContextAnalyzer: Analyzer {
         static let inLoop              = Context(rawValue: 1 << 3)
         // Inside a with statement
         static let inWith              = Context(rawValue: 1 << 4)
+        // Inside a template
+        static let inTemplate          = Context(rawValue: 1 << 5)
     }
     
     private var contextStack = [Context.global]
     
     var context: Context {
         return contextStack.last!
+    }
+
+    mutating func setInTemplate() {
+        contextStack.append([context, .inTemplate])
     }
     
     mutating func analyze(_ instr: Instruction) {

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -267,6 +267,8 @@ extension Instruction: ProtobufConvertible {
                 $0.loadFloat = Fuzzilli_Protobuf_LoadFloat.with { $0.value = op.value }
             case let op as LoadString:
                 $0.loadString = Fuzzilli_Protobuf_LoadString.with { $0.value = op.value }
+            case let op as LoadTemplate:
+                $0.loadTemplate = Fuzzilli_Protobuf_LoadTemplate.with { $0.value = op.value }
             case let op as LoadBoolean:
                 $0.loadBoolean = Fuzzilli_Protobuf_LoadBoolean.with { $0.value = op.value }
             case is LoadUndefined:
@@ -454,6 +456,8 @@ extension Instruction: ProtobufConvertible {
             op = LoadFloat(value: p.value)
         case .loadString(let p):
             op = LoadString(value: p.value)
+        case .loadTemplate(let p):
+            op = LoadTemplate(value: p.value)
         case .loadBoolean(let p):
             op = LoadBoolean(value: p.value)
         case .loadUndefined(_):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -108,6 +108,15 @@ class LoadString: Operation {
     }
 }
 
+class LoadTemplate: Operation {
+    let value: String
+
+    init(value: String) {
+        self.value = value
+        super.init(numInputs: 0, numOutputs: 1, attributes: [.isPrimitive, .isLiteral, .isImmutable])
+    }
+}
+
 class LoadBoolean: Operation {
     let value: Bool
     

--- a/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
+++ b/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
@@ -134,6 +134,9 @@ public struct Type: Hashable {
 
     /// A RegExp
     public static let regexp    = Type(definiteType: .regexp)
+
+    /// A template literal
+    public static let template  = Type(definiteType: .template)
     
     /// A value for which the type is not known.
     public static let unknown   = Type(definiteType: .unknown)
@@ -699,6 +702,8 @@ extension Type: CustomStringConvertible {
             return ".bigint"
         case .regexp:
             return ".regexp"
+        case .template:
+            return ".template"
         case .float:
             return ".float"
         case .string:
@@ -769,6 +774,7 @@ struct BaseType: OptionSet, Hashable {
     static let unknown     = BaseType(rawValue: 1 << 8)
     static let bigint      = BaseType(rawValue: 1 << 9)
     static let regexp      = BaseType(rawValue: 1 << 10)
+    static let template    = BaseType(rawValue: 1 << 11)
     
     /// Additional "flag" types
     static let phi         = BaseType(rawValue: 1 << 30)
@@ -777,9 +783,9 @@ struct BaseType: OptionSet, Hashable {
     static let flagTypes   = BaseType([.phi, .list])
     
     /// The union of all types.
-    static let anything    = BaseType([.undefined, .integer, .float, .string, .boolean, .object, .unknown, .function, .constructor, .bigint, .regexp])
+    static let anything    = BaseType([.undefined, .integer, .float, .string, .boolean, .object, .unknown, .function, .constructor, .bigint, .regexp, .template])
     
-    static let allBaseTypes: [BaseType] = [.undefined, .integer, .float, .string, .boolean, .object, .unknown, .phi, .function, .constructor, .list, .bigint, .regexp]
+    static let allBaseTypes: [BaseType] = [.undefined, .integer, .float, .string, .boolean, .object, .unknown, .phi, .function, .constructor, .list, .bigint, .regexp, .template]
 }
 
 class TypeExtension: Hashable {

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -66,8 +66,9 @@ public class JavaScriptLifter: ComponentBase, Lifter {
             return expressions[v] ?? Identifier.new(v.identifier)
         }
 
-        
-        w.emitBlock(prefix)
+        if !options.contains(.ignorePrefixSuffix){
+            w.emitBlock(prefix)
+        }
         
         let varDecl = version == .es6 ? "let" : "var"
         let constDecl = version == .es6 ? "const" : "var"
@@ -139,6 +140,9 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 
             case let op as LoadString:
                 output = Literal.new() <> "\"" <> op.value <> "\""
+
+            case let op as LoadTemplate:
+                output = Literal.new() <> "`" <> op.value <> "`"
 
             case let op as LoadRegExp:
                 let flags = op.flags.asString()
@@ -495,8 +499,9 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 }
             }
         }
-        
-        w.emitBlock(suffix)
+        if !options.contains(.ignorePrefixSuffix) {
+            w.emitBlock(suffix)
+        }
 
         return w.code
     }

--- a/Sources/Fuzzilli/Lifting/Lifter.swift
+++ b/Sources/Fuzzilli/Lifting/Lifter.swift
@@ -31,4 +31,6 @@ public struct LiftingOptions: OptionSet {
     
     // If enabled, type information for variables will be emitted in comments.
     public static let dumpTypes    = LiftingOptions(rawValue: 1 << 0)
+    // If enabled, the lifted program will not include a prefix and suffix. Used when generating templates
+    public static let ignorePrefixSuffix = LiftingOptions(rawValue: 1 << 1)
 }

--- a/Sources/Fuzzilli/Lifting/ScriptWriter.swift
+++ b/Sources/Fuzzilli/Lifting/ScriptWriter.swift
@@ -24,7 +24,7 @@ struct ScriptWriter {
     
     /// Emit one line of code.
     mutating func emit<S: StringProtocol>(_ line: S) {
-        assert(!line.contains("\n"))
+        //assert(!line.contains("\n"))
         code += String(repeating: " ", count: indention) + line + "\n"
     }
     

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -34,6 +34,8 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = LoadFloat(value: b.genFloat())
         case is LoadString:
             newOp = LoadString(value: b.genString())
+        case is LoadTemplate:
+            newOp = LoadTemplate(value: b.genTemplate())
         case let op as LoadRegExp:
             if probability(0.5) {
                 newOp = LoadRegExp(value: b.genRegExp(), flags: op.flags)

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -328,6 +328,18 @@ public struct Fuzzilli_Protobuf_LoadRegExp {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_LoadTemplate {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var value: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_CreateObject {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1347,6 +1359,35 @@ extension Fuzzilli_Protobuf_LoadRegExp: SwiftProtobuf.Message, SwiftProtobuf._Me
   public static func ==(lhs: Fuzzilli_Protobuf_LoadRegExp, rhs: Fuzzilli_Protobuf_LoadRegExp) -> Bool {
     if lhs.value != rhs.value {return false}
     if lhs.flags != rhs.flags {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_LoadTemplate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".LoadTemplate"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "value"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.value)
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.value.isEmpty {
+      try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_LoadTemplate, rhs: Fuzzilli_Protobuf_LoadTemplate) -> Bool {
+    if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -48,6 +48,10 @@ message LoadRegExp {
     uint32 flags = 2;
 }
 
+message LoadTemplate {
+    string value = 1;
+}
+
 message CreateObject {
     repeated string propertyNames = 1;
 }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -125,6 +125,14 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {_uniqueStorage()._operation = .loadRegExp(newValue)}
   }
 
+  public var loadTemplate: Fuzzilli_Protobuf_LoadTemplate {
+    get {
+      if case .loadTemplate(let v)? = _storage._operation {return v}
+      return Fuzzilli_Protobuf_LoadTemplate()
+    }
+    set {_uniqueStorage()._operation = .loadTemplate(newValue)}
+  }
+
   public var createObject: Fuzzilli_Protobuf_CreateObject {
     get {
       if case .createObject(let v)? = _storage._operation {return v}
@@ -666,6 +674,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case loadUndefined(Fuzzilli_Protobuf_LoadUndefined)
     case loadNull(Fuzzilli_Protobuf_LoadNull)
     case loadRegExp(Fuzzilli_Protobuf_LoadRegExp)
+    case loadTemplate(Fuzzilli_Protobuf_LoadTemplate)
     case createObject(Fuzzilli_Protobuf_CreateObject)
     case createArray(Fuzzilli_Protobuf_CreateArray)
     case createObjectWithSpread(Fuzzilli_Protobuf_CreateObjectWithSpread)
@@ -745,6 +754,7 @@ public struct Fuzzilli_Protobuf_Instruction {
       case (.loadUndefined(let l), .loadUndefined(let r)): return l == r
       case (.loadNull(let l), .loadNull(let r)): return l == r
       case (.loadRegExp(let l), .loadRegExp(let r)): return l == r
+      case (.loadTemplate(let l), .loadTemplate(let r)): return l == r
       case (.createObject(let l), .createObject(let r)): return l == r
       case (.createArray(let l), .createArray(let r)): return l == r
       case (.createObjectWithSpread(let l), .createObjectWithSpread(let r)): return l == r
@@ -851,6 +861,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     9: .same(proto: "loadUndefined"),
     10: .same(proto: "loadNull"),
     77: .same(proto: "loadRegExp"),
+    79: .same(proto: "loadTemplate"),
     11: .same(proto: "createObject"),
     12: .same(proto: "createArray"),
     13: .same(proto: "createObjectWithSpread"),
@@ -1543,6 +1554,14 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           }
           try decoder.decodeSingularMessageField(value: &v)
           if let v = v {_storage._operation = .comment(v)}
+        case 79:
+          var v: Fuzzilli_Protobuf_LoadTemplate?
+          if let current = _storage._operation {
+            try decoder.handleConflictingOneOf()
+            if case .loadTemplate(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._operation = .loadTemplate(v)}
         default: break
         }
       }
@@ -1705,6 +1724,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try visitor.visitSingularMessageField(value: v, fieldNumber: 77)
       case .comment(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 78)
+      case .loadTemplate(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 79)
       case nil: break
       }
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -33,6 +33,7 @@ message Instruction {
         LoadUndefined loadUndefined = 9;
         LoadNull loadNull = 10;
         LoadRegExp loadRegExp = 77;
+        LoadTemplate loadTemplate = 79;
         CreateObject createObject = 11;
         CreateArray createArray = 12;
         CreateObjectWithSpread createObjectWithSpread = 13;

--- a/Sources/FuzzilliCli/Settings.swift
+++ b/Sources/FuzzilliCli/Settings.swift
@@ -89,4 +89,5 @@ let defaultCodeGenerators = WeightedList<CodeGenerator>([
     (LengthChangeGenerator,              5),
     (ElementKindChangeGenerator,         5),
     (PromiseGenerator,                   3),
+    (EvalGenerator,                      2),
 ])

--- a/Tests/FuzzilliTests/MockFuzzer.swift
+++ b/Tests/FuzzilliTests/MockFuzzer.swift
@@ -59,6 +59,7 @@ class MockEnvironment: ComponentBase, Environment {
     var floatType = Type.float
     var booleanType = Type.boolean
     var stringType = Type.string
+    var templateType = Type.template
     var objectType = Type.object()
     var arrayType = Type.object()
 
@@ -260,4 +261,5 @@ fileprivate let testCodeGenerators = WeightedList<CodeGenerator>([
     (LengthChangeGenerator,              1),
     (ElementKindChangeGenerator,         1),
     (PromiseGenerator,                   1),
+    (EvalGenerator,                      1),
     ])


### PR DESCRIPTION
This PR adds a generator to generate instructions of the type:
let v1 = eval(\` ...list of instructions \`)

The [template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) generator doesn't support expression placeholders yet, I shall add this in a future PR.