### PR TITLE
Removes optional from type protobuf

### DIFF
--- a/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
+++ b/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
@@ -906,8 +906,8 @@ extension Type: ProtobufConvertible {
     init(from proto: ProtoType) throws {
         var ext: TypeExtension? = nil
         
-        if !proto.properties.isEmpty || !proto.methods.isEmpty || proto.hasGroup || proto.hasSignature {
-            ext = TypeExtension(group: proto.hasGroup ? proto.group : nil,
+        if !proto.properties.isEmpty || !proto.methods.isEmpty || !proto.group.isEmpty || proto.hasSignature {
+            ext = TypeExtension(group: !proto.group.isEmpty ? proto.group : nil,
                                 properties: Set(proto.properties),
                                 methods: Set(proto.methods),
                                 signature: proto.hasSignature ? try FunctionSignature(from: proto.signature) : nil)

--- a/Sources/Fuzzilli/Protobuf/README.md
+++ b/Sources/Fuzzilli/Protobuf/README.md
@@ -6,4 +6,4 @@ Install the protoc compiler and the swift plugin:
 
 Then generate the swift files:
 
-    protoc --swift_opt=Visibility=Public --experimental_allow_proto3_optional --swift_out=. program.proto operations.proto typesystem.proto sync.proto
+    protoc --swift_opt=Visibility=Public --swift_out=. program.proto operations.proto typesystem.proto sync.proto

--- a/Sources/Fuzzilli/Protobuf/sync.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/sync.pb.swift
@@ -71,9 +71,9 @@ public struct Fuzzilli_Protobuf_FuzzerState {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var corpus: Data = SwiftProtobuf.Internal.emptyData
+  public var corpus: Data = Data()
 
-  public var evaluatorState: Data = SwiftProtobuf.Internal.emptyData
+  public var evaluatorState: Data = Data()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Sources/Fuzzilli/Protobuf/typesystem.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/typesystem.pb.swift
@@ -63,13 +63,9 @@ public struct Fuzzilli_Protobuf_Type {
   }
 
   public var group: String {
-    get {return _storage._group ?? String()}
+    get {return _storage._group}
     set {_uniqueStorage()._group = newValue}
   }
-  /// Returns true if `group` has been explicitly set.
-  public var hasGroup: Bool {return _storage._group != nil}
-  /// Clears the value of `group`. Subsequent reads from it will return its default value.
-  public mutating func clearGroup() {_uniqueStorage()._group = nil}
 
   public var signature: Fuzzilli_Protobuf_FunctionSignature {
     get {return _storage._signature ?? Fuzzilli_Protobuf_FunctionSignature()}
@@ -133,7 +129,7 @@ extension Fuzzilli_Protobuf_Type: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     var _possibleType: UInt32 = 0
     var _properties: [String] = []
     var _methods: [String] = []
-    var _group: String? = nil
+    var _group: String = String()
     var _signature: Fuzzilli_Protobuf_FunctionSignature? = nil
 
     static let defaultInstance = _StorageClass()
@@ -188,8 +184,8 @@ extension Fuzzilli_Protobuf_Type: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       if !_storage._methods.isEmpty {
         try visitor.visitRepeatedStringField(value: _storage._methods, fieldNumber: 4)
       }
-      if let v = _storage._group {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+      if !_storage._group.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._group, fieldNumber: 5)
       }
       if let v = _storage._signature {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 6)

--- a/Sources/Fuzzilli/Protobuf/typesystem.proto
+++ b/Sources/Fuzzilli/Protobuf/typesystem.proto
@@ -23,8 +23,8 @@ message Type {
     uint32 possibleType = 2;
     repeated string properties = 3;
     repeated string methods = 4;
-    optional string group = 5;
-    optional FunctionSignature signature = 6;
+    string group = 5;
+    FunctionSignature signature = 6;
 }
 
 message FunctionSignature {


### PR DESCRIPTION
Since optional is not a standard field in protobuf3, this allows other protobuf tooling to be used