### PR TITLE
Fix special cases in runtime types collection

### DIFF
--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -346,7 +346,7 @@ public class Fuzzer {
     func collectRuntimeTypes(_ program: Program) {
         guard config.collectRuntimeTypes else { return }
         let script = lifter.lift(program, withOptions: .collectTypes)
-        let execution = runner.run(script, withTimeout: 15 * config.timeout)
+        let execution = runner.run(script, withTimeout: 20 * config.timeout)
         // JS prints lines alternating between variable name and its type
         let lines = execution.fuzzout.split(whereSeparator: \.isNewline)
 

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -73,6 +73,9 @@ public class JavaScriptLifter: ComponentBase, Lifter {
         }
 
         if options.contains(.collectTypes) {
+            // Wrap type collection to its own main function to avoid using global variables
+            w.emit("function typeCollectionMain() {")
+            w.increaseIndentionLevel()
             w.emitBlock(helpersScript)
             w.emitBlock(initTypeCollectionScript)
         }
@@ -533,6 +536,9 @@ public class JavaScriptLifter: ComponentBase, Lifter {
 
         if options.contains(.collectTypes) {
             w.emitBlock(printTypesScript)
+            w.decreaseIndentionLevel()
+            w.emit("}")
+            w.emit("typeCollectionMain()")
         }
 
         return w.code

--- a/Sources/JS/helpers.js
+++ b/Sources/JS/helpers.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 var maxCollectedProperties = 200
+var maxLevelCheckProperties = 10000
 // Note that order of the groups is important because we assign object to the first matching group.
 // For example Object is group containing other groups, so it should be placed at the end
 var possibleGroups = [
@@ -55,6 +56,8 @@ var baseTypes = {
 // Back up important functions needed to type collection
 var isInteger = Number.isInteger
 var getObjectPropertyNames = Object.getOwnPropertyNames
+var getObjectKeys = Object.keys
+var mathMin = Math.min
 // Check if we can use property name in form obj.prop
 // http://www.ecma-international.org/ecma-262/6.0/#sec-names-and-keywords
 function isValidPropName(name) {

--- a/Sources/JS/helpers.swift
+++ b/Sources/JS/helpers.swift
@@ -15,6 +15,7 @@
 // limitations under the License.
 public let helpersScript = """
 var maxCollectedProperties = 200
+var maxLevelCheckProperties = 10000
 var possibleGroups = [
     {name: "Symbol", belongsToGroup: function(obj){typeof obj == 'symbol'}},
     {name: "String", belongsToGroup: function(obj){return obj instanceof String}},
@@ -54,6 +55,8 @@ var baseTypes = {
 }
 var isInteger = Number.isInteger
 var getObjectPropertyNames = Object.getOwnPropertyNames
+var getObjectKeys = Object.keys
+var mathMin = Math.min
 function isValidPropName(name) {
     return /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name)
 }

--- a/Sources/JS/initTypeCollection.js
+++ b/Sources/JS/initTypeCollection.js
@@ -65,7 +65,9 @@ function getCurrentType(value){
             currentType.setGroup(value)
             while (value != null) {
                 var propertyNames = getObjectPropertyNames(value)
-                for (var i=0;i<propertyNames.length;i++) {
+                // Avoid checking too many properties
+                var propertiesNumber = mathMin(propertyNames.length, maxLevelCheckProperties)
+                for (var i=0;i<propertiesNumber;i++) {
                     var name = propertyNames[i]
                     if (currentType.properties.size >= maxCollectedProperties) break
                     if (!isValidPropName(name)) continue

--- a/Sources/JS/initTypeCollection.swift
+++ b/Sources/JS/initTypeCollection.swift
@@ -67,7 +67,9 @@ function getCurrentType(value){
             currentType.setGroup(value)
             while (value != null) {
                 var propertyNames = getObjectPropertyNames(value)
-                for (var i=0;i<propertyNames.length;i++) {
+                // Avoid checking too many properties
+                var propertiesNumber = mathMin(propertyNames.length, maxLevelCheckProperties)
+                for (var i=0;i<propertiesNumber;i++) {
                     var name = propertyNames[i]
                     if (currentType.properties.size >= maxCollectedProperties) break
                     if (!isValidPropName(name)) continue

--- a/Sources/JS/printTypes.js
+++ b/Sources/JS/printTypes.js
@@ -11,7 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-for (var varNumber in types) {
+var varNumbers = getObjectKeys(types)
+// Do not use for in to avoid iterating over prototype properties
+for (var i=0;i<varNumbers.length;i++) {
+    var varNumber = varNumbers[i]
     fuzzilli('FUZZILLI_PRINT', varNumber)
     fuzzilli('FUZZILLI_PRINT', JSON.stringify(types[varNumber]))
 }

--- a/Sources/JS/printTypes.swift
+++ b/Sources/JS/printTypes.swift
@@ -14,7 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 public let printTypesScript = """
-for (var varNumber in types) {
+var varNumbers = getObjectKeys(types)
+for (var i=0;i<varNumbers.length;i++) {
+    var varNumber = varNumbers[i]
     fuzzilli('FUZZILLI_PRINT', varNumber)
     fuzzilli('FUZZILLI_PRINT', JSON.stringify(types[varNumber]))
 }


### PR DESCRIPTION
Fix cases when generated JS code messes with our runtime types collection, specifically:

Object prototype properties change:
```
const v0 = Object;
updateType(0, v0)
const v1 = v0.prototype;
updateType(1, v1)
v1.c = v1;
updateType(1, v1)
```

Generated code changes global variables:
```
for (v0 in this) {
    this[v0][42] = "foobar";
}
```

Too slow when collecting properties of large arrays:
```
const v0 = 1000000
updateType(0, v0)
const v1 = Uint8Array
updateType(1, v1)
const v2 = new v1(v0)
updateType(2, v2)
```