### PR TITLE
Skip checking long arrays properties & small related refactor

### DIFF
--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -347,7 +347,7 @@ public class Fuzzer {
         precondition(program.typeCollectionStatus == .notAttempted)
         guard config.collectRuntimeTypes else { return }
         let script = lifter.lift(program, withOptions: .collectTypes)
-        let execution = runner.run(script, withTimeout: 20 * config.timeout)
+        let execution = runner.run(script, withTimeout: 30 * config.timeout)
         // JS prints lines alternating between variable name and its type
         let lines = execution.fuzzout.split(whereSeparator: \.isNewline)
 

--- a/Sources/JS/helpers.swift
+++ b/Sources/JS/helpers.swift
@@ -15,29 +15,35 @@
 // limitations under the License.
 public let helpersScript = """
 var maxCollectedProperties = 200
-var maxLevelCheckProperties = 10000
-var possibleGroups = [
-    {name: "Symbol", belongsToGroup: function(obj){typeof obj === 'symbol'}},
-    {name: "String", belongsToGroup: function(obj){return obj instanceof String}},
-    {name: "RegExp", belongsToGroup: function(obj){return obj instanceof RegExp}},
-    {name: "Array", belongsToGroup: function(obj){return obj instanceof Array}},
-    {name: "Map", belongsToGroup: function(obj){return obj instanceof Map}},
-    {name: "Promise", belongsToGroup: function(obj){return obj instanceof Promise}},
-    {name: "WeakMap", belongsToGroup: function(obj){return obj instanceof WeakMap}},
-    {name: "Set", belongsToGroup: function(obj){return obj instanceof Set}},
-    {name: "WeakSet", belongsToGroup: function(obj){return obj instanceof WeakSet}},
-    {name: "ArrayBuffer", belongsToGroup: function(obj){return obj instanceof ArrayBuffer}},
-    {name: "DataView", belongsToGroup: function(obj){return obj instanceof DataView}},
-    {name: "Uint8Array", belongsToGroup: function(obj){return obj instanceof Uint8Array}},
-    {name: "Int8Array", belongsToGroup: function(obj){return obj instanceof Int8Array}},
-    {name: "Uint16Array", belongsToGroup: function(obj){return obj instanceof Uint16Array}},
-    {name: "Int16Array", belongsToGroup: function(obj){return obj instanceof Int16Array}},
-    {name: "Uint32Array", belongsToGroup: function(obj){return obj instanceof Uint32Array}},
-    {name: "Int32Array", belongsToGroup: function(obj){return obj instanceof Int32Array}},
-    {name: "Float32Array", belongsToGroup: function(obj){return obj instanceof Float32Array}},
-    {name: "Float64Array", belongsToGroup: function(obj){return obj instanceof Float64Array}},
-    {name: "Uint8ClampedArray", belongsToGroup: function(obj){return obj instanceof String}},
-    {name: "Object", belongsToGroup: function(obj){return obj instanceof Object}},
+var maxArrayLength = 1000
+var groups = {
+    symbol: {name: "Symbol", belongsToGroup: function(obj){return typeof obj === 'symbol'}},
+    string: {name: "String", belongsToGroup: function(obj){return obj instanceof String}},
+    regexp: {name: "RegExp", belongsToGroup: function(obj){return obj instanceof RegExp}},
+    array: {name: "Array", belongsToGroup: function(obj){return obj instanceof Array}},
+    map: {name: "Map", belongsToGroup: function(obj){return obj instanceof Map}},
+    promise: {name: "Promise", belongsToGroup: function(obj){return obj instanceof Promise}},
+    weakMap: {name: "WeakMap", belongsToGroup: function(obj){return obj instanceof WeakMap}},
+    set: {name: "Set", belongsToGroup: function(obj){return obj instanceof Set}},
+    weakSet: {name: "WeakSet", belongsToGroup: function(obj){return obj instanceof WeakSet}},
+    arrayBuffer: {name: "ArrayBuffer", belongsToGroup: function(obj){return obj instanceof ArrayBuffer}},
+    dataView: {name: "DataView", belongsToGroup: function(obj){return obj instanceof DataView}},
+    uint8Array: {name: "Uint8Array", belongsToGroup: function(obj){return obj instanceof Uint8Array}, slowTypeCollection: true},
+    int8Array: {name: "Int8Array", belongsToGroup: function(obj){return obj instanceof Int8Array}, slowTypeCollection: true},
+    uint16Array: {name: "Uint16Array", belongsToGroup: function(obj){return obj instanceof Uint16Array}, slowTypeCollection: true},
+    int16Array: {name: "Int16Array", belongsToGroup: function(obj){return obj instanceof Int16Array}, slowTypeCollection: true},
+    uint32Array: {name: "Uint32Array", belongsToGroup: function(obj){return obj instanceof Uint32Array}, slowTypeCollection: true},
+    int32Array: {name: "Int32Array", belongsToGroup: function(obj){return obj instanceof Int32Array}, slowTypeCollection: true},
+    float32Array: {name: "Float32Array", belongsToGroup: function(obj){return obj instanceof Float32Array}, slowTypeCollection: true},
+    float64Array: {name: "Float64Array", belongsToGroup: function(obj){return obj instanceof Float64Array}, slowTypeCollection: true},
+    uint8ClampedArray: {name: "Uint8ClampedArray", belongsToGroup: function(obj){return obj instanceof Uint8ClampedArray}, slowTypeCollection: true},
+    object: {name: "Object", belongsToGroup: function(obj){return obj instanceof Object}}
+}
+var orderedGroups = [
+    groups.symbol, groups.string, groups.regexp, groups.array, groups.map, groups.promise, groups.weakMap, groups.set,
+    groups.weakSet, groups.arrayBuffer, groups.dataView, groups.uint8Array, groups.int8Array, groups.uint16Array,
+    groups.int16Array, groups.uint32Array, groups.int32Array, groups.float32Array, groups.float64Array,
+    groups.uint8ClampedArray, groups.object,
 ]
 var baseTypes = {
     nothing: 0,
@@ -57,6 +63,7 @@ var isInteger = Number.isInteger
 var getObjectPropertyNames = Object.getOwnPropertyNames
 var getObjectKeys = Object.keys
 var mathMin = Math.min
+var jsonStringify = JSON.stringify
 function isValidPropName(name) {
     return /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name)
 }

--- a/Sources/JS/initTypeCollection.js
+++ b/Sources/JS/initTypeCollection.js
@@ -11,7 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-function Type() {}
+function Type(rawValue) {
+    if(rawValue == null) return
+    this.definiteType = rawValue
+    this.possibleType = rawValue
+    if (rawValue === baseTypes.object) {
+        this.properties = []
+        this.methods = []
+    }
+}
 Type.prototype.union = function(otherType) {
     var newType = new Type()
     newType.definiteType = this.definiteType & otherType.definiteType
@@ -24,11 +32,11 @@ Type.prototype.union = function(otherType) {
     return newType
 }
 Type.prototype.setGroup = function(obj) {
-    for (var i=0;i<possibleGroups.length;i++) {
+    for (var i=0;i<orderedGroups.length;i++) {
         try {
-            if (possibleGroups[i].belongsToGroup(obj)) {
-                this.group = possibleGroups[i].name
-                return
+            if (orderedGroups[i].belongsToGroup(obj)) {
+                this.group = orderedGroups[i].name
+                return orderedGroups[i]
             }
         } catch(err) {}
     }
@@ -36,38 +44,31 @@ Type.prototype.setGroup = function(obj) {
 
 // variableNumber: Type
 var types = {}
-function getBaseType(rawValue) {
-    var newType = new Type()
-    newType.definiteType = rawValue
-    newType.possibleType = rawValue
-    if (rawValue === baseTypes.object) {
-        newType.properties = []
-        newType.methods = []
-    }
-    return newType
-}
 function getCurrentType(value){
     try {
         // Fuzzilli handles both null/undefined as undefined
-        if (value == null) return getBaseType(baseTypes.undefined)
+        if (value == null) return new Type(baseTypes.undefined)
         try {
-            if (isInteger(value)) return getBaseType(baseTypes.integer)
+            if (isInteger(value)) return new Type(baseTypes.integer)
         } catch(err) {}
-        if (typeof value === 'number') return getBaseType(baseTypes.float)
-        if (typeof value === 'string') return getBaseType(baseTypes.string)
-        if (typeof value === 'boolean') return getBaseType(baseTypes.boolean)
-        if (typeof value === 'bigint') return getBaseType(baseTypes.bigint)
+        if (typeof value === 'number') return new Type(baseTypes.float)
+        if (typeof value === 'string') return new Type(baseTypes.string)
+        if (typeof value === 'boolean') return new Type(baseTypes.boolean)
+        if (typeof value === 'bigint') return new Type(baseTypes.bigint)
         try {
-            if (value instanceof RegExp) return getBaseType(baseTypes.regexp)
+            if (value instanceof RegExp) return new Type(baseTypes.regexp)
         } catch(err) {}
         if (typeof value === 'object' || typeof value === 'symbol') {
-            var currentType = getBaseType(baseTypes.object)
-            currentType.setGroup(value)
+            var currentType = new Type(baseTypes.object)
+            var group = currentType.setGroup(value)
+            // handle long arrays specially to reduce time spent on properties collection
+            if (group && group.slowTypeCollection && value.length > maxArrayLength) {
+                currentType.properties.push('length')
+                value = value.__proto__
+            }
             while (value != null) {
                 var propertyNames = getObjectPropertyNames(value)
-                // Avoid checking too many properties
-                var propertiesNumber = mathMin(propertyNames.length, maxLevelCheckProperties)
-                for (var i=0;i<propertiesNumber;i++) {
+                for (var i=0;i<propertyNames.length;i++) {
                     var name = propertyNames[i]
                     if (currentType.properties.length >= maxCollectedProperties) break
                     if (!isValidPropName(name)) continue
@@ -84,7 +85,7 @@ function getCurrentType(value){
             return currentType
         }
         // Set unknown if no type was matched
-        return getBaseType(baseTypes.unknown)
+        return new Type(baseTypes.unknown)
     } catch(err) {}
 }
 function updateType(number, value) {

--- a/Sources/JS/printTypes.js
+++ b/Sources/JS/printTypes.js
@@ -16,5 +16,5 @@ var varNumbers = getObjectKeys(types)
 for (var i=0;i<varNumbers.length;i++) {
     var varNumber = varNumbers[i]
     fuzzilli('FUZZILLI_PRINT', varNumber)
-    fuzzilli('FUZZILLI_PRINT', JSON.stringify(types[varNumber]))
+    fuzzilli('FUZZILLI_PRINT', jsonStringify(types[varNumber]))
 }

--- a/Sources/JS/printTypes.swift
+++ b/Sources/JS/printTypes.swift
@@ -18,6 +18,6 @@ var varNumbers = getObjectKeys(types)
 for (var i=0;i<varNumbers.length;i++) {
     var varNumber = varNumbers[i]
     fuzzilli('FUZZILLI_PRINT', varNumber)
-    fuzzilli('FUZZILLI_PRINT', JSON.stringify(types[varNumber]))
+    fuzzilli('FUZZILLI_PRINT', jsonStringify(types[varNumber]))
 }
 """


### PR DESCRIPTION
* Back up `JSON.stringify` function
* move `getBaseType` to constructor
* increase timelimit
* refactor groups
* mark some groups with `slowTypeCollection` and skip their properties collection
  because of slow execution of
  ```
  const v0 = new Uint32Array(1000000) //fast
  updateType(0,v0) //slow because of Object.getOwnPropertyNames(v0)
  ```