### PR TITLE
Fuzzilli Compiler Support - Initial

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
         .target(name: "REPRLRun", dependencies: ["libreprl"]),
         .target(name: "FuzzilliCli", dependencies: ["Fuzzilli"]),
         .target(name: "JS", dependencies: []),
+        .target(name: "FuzzILTool", dependencies: ["Fuzzilli"]),
 
         .testTarget(name: "FuzzilliTests", dependencies: ["Fuzzilli"]),
     ],

--- a/Sources/FuzzILTool/main.swift
+++ b/Sources/FuzzILTool/main.swift
@@ -1,0 +1,251 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Fuzzilli
+
+let jsFileExtension = ".js"
+let protoBufFileExtension = ".il.protobuf"
+
+let corpus = Corpus(minSize: 1000, maxSize: 1000000, minMutationsPerSample: 600)
+let jsPrefix = """
+               """
+let jsSuffix = """
+               """
+let lifter = JavaScriptLifter(prefix: jsPrefix,
+                suffix: jsSuffix,
+                inliningPolicy: NeverInline(),
+                ecmaVersion: ECMAScriptVersion.es6,
+                environment: JavaScriptEnvironment(additionalBuiltins: [:], additionalObjectGroups: []))
+
+
+func importFuzzILState(data: Data) throws {
+    let state = try Fuzzilli_Protobuf_FuzzerState(serializedData: data)
+    try corpus.importState(state.corpus)
+}
+
+// Takes a path, and stores each program to an individual file in that folder
+func dumpProtobufs(dumpPath: String) throws {
+    // Check if folder exists. If not, make it
+    do {
+        try FileManager.default.createDirectory(atPath: dumpPath, withIntermediateDirectories: true)
+    } catch {
+        print("Failed to create directory for protobuf splitting. Is folder \(dumpPath) configured correctly?")
+        exit(-1)
+    }
+    // Write each program as a protobuf to individual files
+    var prog_index = 0
+    for prog in corpus {
+        let name = "prog_\(prog_index).il.protobuf"
+        let progURL = URL(fileURLWithPath: "\(dumpPath)/\(name)")
+        do {
+            let serializedProg = try prog.asProtobuf().serializedData()
+            try serializedProg.write(to: progURL)
+        } catch {
+            print("Failed to serialize program. Skipping")
+        }
+        prog_index += 1
+    }
+}
+
+// Read in a protobuf
+func readProtoToString(path: String) throws -> String {
+    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+    let proto = try Fuzzilli_Protobuf_Program(serializedData: data)
+    var resString = String()
+    dump(proto, to:&resString, maxDepth: 3)
+    return resString
+}
+
+// Convert a serialized protobuf file to a FuzzIL program
+func protobufToProgram(path: String) throws -> Program {
+    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+    let proto = try Fuzzilli_Protobuf_Program(serializedData: data)
+    let program = try Program(from: proto)
+    return program
+}
+
+// Take a program and lifts it to a JS script
+func liftToJS(prog: Program) -> String {
+    let res = lifter.lift(prog)
+    return res.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+// Prints a Fuzzilli program as a string
+func getPrettyStringProgram(program: Program) -> String {
+    var resString = String()
+    dump(program, to: &resString)
+    return resString.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+// Takes all .il.protobuf files in a directory, and lifts them to JS
+// Returns the number of files successfully converted
+func compileAllProtosToJS(dirPath: String) throws -> Int {
+    let fileEnumerator = FileManager.default.enumerator(atPath: dirPath)
+    var count = 0
+    while let fileName = fileEnumerator?.nextObject() as? String {
+        guard fileName.hasSuffix(protoBufFileExtension) else { continue }
+        let fullPath = dirPath + fileName
+        let prog = try protobufToProgram(path: fullPath)
+        let jsProgString = liftToJS(prog: prog)
+        let newFilePath = dirPath + String(fileName.dropLast(protoBufFileExtension.count)) + jsFileExtension
+        try jsProgString.write(to: URL(fileURLWithPath: newFilePath), atomically: false, encoding: String.Encoding.utf8)
+        count += 1
+    }
+    return count
+}
+
+// Provided a directory with a bunch of protobuf files, combine them all into a corpus file for consumption by Fuzzilli
+func combineProtobufs(dirPath: String, outputFile: String) throws -> Int {
+    let fileEnumerator = FileManager.default.enumerator(atPath: dirPath)
+    var failed_count = 0
+    var progs = [Program]()
+    while let fileName = fileEnumerator?.nextObject() as? String {
+        guard fileName.hasSuffix(protoBufFileExtension) else { continue }
+        let fullPath = dirPath + fileName
+        var prog = Program()
+        do {
+            prog = try protobufToProgram(path: fullPath)
+            progs.append(prog)
+        } catch {
+            print("Failed to convert to program \(fileName) with error \(error)")
+            failed_count += 1
+            continue
+        }
+    }
+
+    let buf = try encodeProtobufCorpus(progs)
+    let url = URL(fileURLWithPath: outputFile)
+    try buf.write(to: url)
+    print("Successfully converted \(progs.count) failed \(failed_count)")
+    return progs.count
+}
+
+let args = Arguments.parse(from: CommandLine.arguments)
+
+if args["-h"] != nil || args["--help"] != nil || args.numPositionalArguments != 0 {
+    print("""
+          Usage:
+          \(args.programName) [options] 
+
+          Options:
+              --fuzzILState=path          : Path of a FuzzIL state file 
+              --splitState=path           : Splits out a fuzzil profile into individual protobuf programs in specified file
+              --combineBuffs=path         : Combines all encoded protobufs in a folder into a single fuzzilli state.
+              --ILToJS=path               : Takes a single protobuf file and converts it to JS     
+              --printProtobufAsProg=path  : Takes a single protobuf file and pretty prints it as a Fuzzilli program
+              --printProtobuf=path        : Takes a single protobuf file and pretty prints it as a Protobuf
+              --dirILToJS=path            : Takes all of the .il.protobuf files in an directory, and produces .js files in that same directory  
+              --combineProtoDir=path      : combines all of the .il.protobuf files in a directory into a corpus.bin file for consumption by Fuzzilli
+          """)
+    exit(0)
+}
+
+
+let fuzzILPath = args["--fuzzILState"]
+let splitStatePath = args["--splitState"]
+let combineBuffsPath = args["--combineBuffs"]
+let ilToJSPath = args["--ILToJS"]
+let printProtoAsProgPath = args["--printProtobufAsProg"]
+let printProtoPath = args["--printProtobuf"]
+let dirILToJS = args["--dirILToJS"]
+let combineDir = args["--combineProtoDir"]
+
+if splitStatePath != nil && fuzzILPath == nil {
+    print("Splitting state requires fuzzILState to be set")
+    exit(-1)
+}
+
+// Split out an already built state
+if let splitPath = splitStatePath, let statePath = fuzzILPath {
+    do {
+        let data = try Data(contentsOf: URL(fileURLWithPath: statePath))
+        try importFuzzILState(data: data)
+        try dumpProtobufs(dumpPath: splitPath)
+    } catch {
+        print("Failed to import FuzzIL State with \(error)")
+        exit(-1)
+    }
+}
+
+// Covert a single IL protobuf file to JS and print to stdout
+else if let ilPath = ilToJSPath {
+    var prog = Program()
+    do {
+        prog = try protobufToProgram(path: ilPath)
+    } catch {
+        print("Failed to load il proto \(ilPath) with error \(error)")
+        exit(-1)
+    }
+    let jsProgString = liftToJS(prog: prog)
+    print(jsProgString)
+}
+
+// Pretty print just the protobuf, without trying to load as a program
+// This allows the debugging of produced programs that are not syntactically valid
+else if let printPath = printProtoPath {
+    let res = try readProtoToString(path: printPath)
+    print(res)
+}
+
+
+// Pretty print a protobuf as a program on stdout
+else if let printPath = printProtoAsProgPath {
+    var prog = Program()
+    do {
+        prog = try protobufToProgram(path: printPath)
+    } catch {
+        print("Failed to load il proto \(printPath) with error \(error)")
+        exit(-1)
+    }
+    let prettyProgString = getPrettyStringProgram(program: prog)
+    print(prettyProgString)
+}
+
+// Produce JS files from protobufs
+else if let dirPath = dirILToJS {
+    var isDir : ObjCBool = false
+    if !FileManager.default.fileExists(atPath: dirPath, isDirectory:&isDir) || !isDir.boolValue {
+        print("Provided directory \(dirPath) is not a valid directory path")
+        exit(-1)
+    }
+    do {
+        let numConverted = try compileAllProtosToJS(dirPath: dirPath)
+        print("Successfully converted \(numConverted) files")
+    } catch {
+        print("Failed to compile protos with error \(error)")
+        exit(-1)
+    }
+}
+
+// Combine a bunch of protobufs into a state json
+else if let dirPath = combineDir {
+    var isDir : ObjCBool = false
+    if !FileManager.default.fileExists(atPath: dirPath, isDirectory:&isDir) || !isDir.boolValue {
+        print("Provided directory \(dirPath) is not a valid directory path")
+        exit(-1)
+    }
+    do {
+        let numConverted = try combineProtobufs(dirPath: dirPath, outputFile: "corpus.bin")
+        print("Successfully combined \(numConverted) files into corpus.bin")
+    } catch {
+        print("Failed to combine protos with error \(error)")
+        exit(-1)
+    }
+}
+
+else {
+    print("Please enter a command to use")
+    exit(-1)
+}

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -30,8 +30,8 @@ public struct AbstractInterpreter {
     // The environment model from which to obtain various pieces of type information.
     private let environment: Environment
     
-    init(for fuzzer: Fuzzer) {
-        self.environment = fuzzer.environment
+    init(for environ: Environment) {
+        self.environment = environ
     }
     
     public mutating func reset() {

--- a/Sources/Fuzzilli/FuzzIL/Program.swift
+++ b/Sources/Fuzzilli/FuzzIL/Program.swift
@@ -266,7 +266,7 @@ public func ==(lhs: Program.CheckResult, rhs: Program.CheckResult) -> Bool {
 }
 
 extension Program: ProtobufConvertible {
-    typealias ProtoType = Fuzzilli_Protobuf_Program
+    public typealias ProtoType = Fuzzilli_Protobuf_Program
 
     func asProtobuf(with opCache: OperationCache?) -> ProtoType {
         return ProtoType.with {
@@ -278,11 +278,11 @@ extension Program: ProtobufConvertible {
         }
     }
     
-    func asProtobuf() -> ProtoType {
+    public func asProtobuf() -> ProtoType {
         return asProtobuf(with: nil)
     }
     
-    convenience init(from proto: ProtoType, with opCache: OperationCache?) throws {
+    public convenience init(from proto: ProtoType, with opCache: OperationCache?) throws {
         self.init()
         for protoInstr in proto.instructions {
             append(try Instruction(from: protoInstr, with: opCache))
@@ -299,7 +299,7 @@ extension Program: ProtobufConvertible {
         }
     }
     
-    convenience init(from proto: ProtoType) throws {
+    public convenience init(from proto: ProtoType) throws {
         try self.init(from: proto, with: nil)
     }
 }

--- a/Sources/Fuzzilli/Lifting/InliningPolicy.swift
+++ b/Sources/Fuzzilli/Lifting/InliningPolicy.swift
@@ -17,12 +17,14 @@ public protocol InliningPolicy {
 }
 
 public struct AlwaysInline: InliningPolicy {
+    public init() {}
     public func shouldInline(_ expr: Expression) -> Bool {
         return true
     }
 }
 
 public struct NeverInline: InliningPolicy {
+    public init() {}
     public func shouldInline(_ expr: Expression) -> Bool {
         return false
     }

--- a/Sources/Fuzzilli/Protobuf/ProtoUtils.swift
+++ b/Sources/Fuzzilli/Protobuf/ProtoUtils.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
+
 // Protocol for objects that have a corresponding Protobuf message.
 protocol ProtobufConvertible {
     associatedtype ProtobufType
@@ -24,7 +26,7 @@ protocol ProtobufConvertible {
 // This enables the "compressed" protobuf program encoding in
 // which an duplicate operation can be replaced with the index
 // its first occurance in the serialized data.
-class OperationCache {
+public class OperationCache {
     // Maps Operations to the index of their owning instruction in the output data.
     private var indices: [ObjectIdentifier: Int]? = nil
     // Maps indices to their operation.
@@ -64,3 +66,52 @@ class OperationCache {
         operations.append(operation)
     }
 }
+
+public func encodeProtobufCorpus<T: Collection>(_ programs: T) throws -> Data where T.Element == Program  {
+    // This does streaming serialization to keep memory usage as low as possible.
+    // Also, this uses the operation compression feature of our protobuf representation:
+    // when the same operation occurs multiple times in the corpus, every subsequent
+    // occurance in the protobuf is simply the index of instruction with the first occurance.
+    //
+    // The binary format is simply
+    //    [ program1 | program2 | ... | programN ]
+    // where every program is encoded as
+    //    [ size without padding in bytes as uint32 | serialized program protobuf | padding ]
+    // The padding ensures 4 byte alignment of every program.
+    //        
+
+    var buf = Data()
+    let opCache = OperationCache.forEncoding()
+    for program in programs {
+        let proto = program.asProtobuf(with: opCache)
+        let serializedProgram = try proto.serializedData()
+        var size = UInt32(serializedProgram.count).littleEndian
+        buf.append(Data(bytes: &size, count: 4))
+        buf.append(serializedProgram)
+        // Align to 4 bytes
+        buf.append(Data(count: align(buf.count, to: 4)))
+    }
+    return buf
+}
+
+public func decodeProtobufCorpus(_ buffer: Data) throws -> [Program]{
+    let opCache = OperationCache.forDecoding()
+    var offset = 0
+    
+    var newPrograms = [Program]()
+    while offset + 4 < buffer.count {
+        let value = buffer.withUnsafeBytes { $0.load(fromByteOffset: offset, as: UInt32.self) }
+        let size = Int(UInt32(littleEndian: value))
+        offset += 4
+        guard offset + size <= buffer.count else {
+            throw FuzzilliError.corpusImportError("Invalid program size in corpus")
+        }
+        let data = buffer.subdata(in: offset..<offset+size)
+        offset += size + align(size, to: 4)
+        let proto = try Fuzzilli_Protobuf_Program(serializedData: data)
+        let program = try Program(from: proto, with: opCache)
+        newPrograms.append(program)
+    }
+    return newPrograms
+}
+

--- a/Sources/Fuzzilli/Util/Arguments.swift
+++ b/Sources/Fuzzilli/Util/Arguments.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 /// Provides conventient access to a program's command line arguments.
-class Arguments {
-    let programName: String
+public class Arguments {
+    public let programName: String
     
-    var numPositionalArguments: Int {
+    public var numPositionalArguments: Int {
         return positionalArguments.count
     }
     
@@ -33,21 +33,21 @@ class Arguments {
         unusedOptionals = Set<String>(optionalArguments.keys)
     }
     
-    private func useArgument(_ key: String) -> String? {
+    public func useArgument(_ key: String) -> String? {
         unusedOptionals.remove(key)
         return optionalArguments[key]
     }
     
-    subscript(index: Int) -> String {
+    public subscript(index: Int) -> String {
         return positionalArguments[index]
     }
     
-    subscript(name: String) -> String? {
+    public subscript(name: String) -> String? {
         let key = String(name.drop(while: { $0 == "-" }))
         return useArgument(key)
     }
     
-    func int(for name: String) -> Int? {
+    public func int(for name: String) -> Int? {
         if let value = self[name] {
             return Int(value)
         } else {
@@ -55,7 +55,7 @@ class Arguments {
         }
     }
     
-    func uint(for name: String) -> UInt? {
+    public func uint(for name: String) -> UInt? {
         if let value = self[name] {
             return UInt(value)
         } else {
@@ -63,7 +63,7 @@ class Arguments {
         }
     }
     
-    func bool(for name: String) -> Bool? {
+    public func bool(for name: String) -> Bool? {
         if let value = self[name] {
             return Bool(value)
         } else {
@@ -71,11 +71,11 @@ class Arguments {
         }
     }
     
-    func has(_ name: String) -> Bool {
+    public func has(_ name: String) -> Bool {
         return self[name] != nil
     }
     
-    static func parse(from args: [String]) -> Arguments {
+    public static func parse(from args: [String]) -> Arguments {
         var positionalArguments = [String]()
         var optionalArguments = [String: String]()
         
@@ -96,7 +96,7 @@ class Arguments {
 }
 
 /// Parses a hostname and port from a string of the format "hostname:port".
-func parseHostPort(_ s: String) -> (String, UInt16)? {
+public func parseHostPort(_ s: String) -> (String, UInt16)? {
     let parts = s.split(separator: ":")
     guard parts.count == 2 else {
         return nil

--- a/Sources/Fuzzilli/Util/Misc.swift
+++ b/Sources/Fuzzilli/Util/Misc.swift
@@ -26,7 +26,7 @@ func uniqueElements<E>(of list: [E]) -> [E] where E: Hashable {
     return Array(Set(list))
 }
 
- func align(_ v: Int, to desiredAlignment: Int) -> Int {
+func align(_ v: Int, to desiredAlignment: Int) -> Int {
     let remainder = v % desiredAlignment
     return remainder != 0 ? desiredAlignment - remainder : 0
 }
@@ -37,3 +37,4 @@ func measureTime<R>(_ operation: () -> R) -> (R, Double) {
     let end = Date()
     return (r, end.timeIntervalSince(start))
 }
+

--- a/Tests/FuzzilliTests/MockFuzzer.swift
+++ b/Tests/FuzzilliTests/MockFuzzer.swift
@@ -163,7 +163,7 @@ func makeMockFuzzer(runner maybeRunner: ScriptRunner? = nil, environment maybeEn
     let environment = maybeEnvironment ?? MockEnvironment(builtins: ["Foo": .integer, "Bar": .object(), "Baz": .function()])
     
     // A lifter to translate FuzzIL programs to JavaScript.
-    let lifter = JavaScriptLifter(prefix: "", suffix: "", inliningPolicy: InlineOnlyLiterals(), ecmaVersion: .es6)
+    let lifter = JavaScriptLifter(prefix: "", suffix: "", inliningPolicy: InlineOnlyLiterals(), ecmaVersion: .es6, environment: environment)
     
     // Corpus managing interesting programs that have been found during fuzzing.
     let corpus = Corpus(minSize: 1000, maxSize: 2000, minMutationsPerSample: 5)


### PR DESCRIPTION
This commit provides support in Fuzzilli for initial compiler development, such as combining individual program protobufs, and doing a corpus import.

Initial step towards #4 

There are some things I know I need to clean up (such as the arguments file), but i'd appreciate feedback on the commit as a whole first.

Also, I'm not sure why the extraneous commits are showing, but the solutions I got by googling the issue have been ineffective.

Thanks!