### PR TITLE
Support Block Statement generation

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -545,6 +545,12 @@ public let CodeGenerators: [CodeGenerator] = [
         let eval = b.loadBuiltin("eval")
         b.callFunction(eval, withArgs: [code])
     },
+
+    CodeGenerator("BlockStatementGenerator") { b in
+        b.blockStatement(){
+            b.generateRecursive()
+        }
+    },
 ]
 
 extension Array where Element == CodeGenerator {

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -885,6 +885,12 @@ public class ProgramBuilder {
         return instruction.output
     }
 
+    public func blockStatement(_ body: () -> Void) {
+        perform(BeginBlockStatement())
+        body()
+        perform(EndBlockStatement())
+    }
+
     public func doPrint(_ value: Variable) {
         perform(Print(), withInputs: [value])
     }

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -103,6 +103,10 @@ public struct AbstractInterpreter {
             break
         case is EndCodeString:
             break
+        case is BeginBlockStatement:
+            break
+        case is EndBlockStatement:
+            break
         default:
             assert(instr.isSimple)
         }

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -416,6 +416,10 @@ extension Instruction: ProtobufConvertible {
                 $0.beginCodeString = Fuzzilli_Protobuf_BeginCodeString()
             case is EndCodeString:
                 $0.endCodeString = Fuzzilli_Protobuf_EndCodeString()
+            case is BeginBlockStatement:
+                $0.beginBlockStatement = Fuzzilli_Protobuf_BeginBlockStatement()
+            case is EndBlockStatement:
+                $0.endBlockStatement = Fuzzilli_Protobuf_EndBlockStatement()
             default:
                 fatalError("Unhandled operation type in protobuf conversion: \(operation)")
             }
@@ -608,6 +612,10 @@ extension Instruction: ProtobufConvertible {
             op = BeginCodeString()
         case .endCodeString(_):
             op = EndCodeString()
+        case .beginBlockStatement(_):
+            op = BeginBlockStatement()
+        case .endBlockStatement(_):
+            op = EndBlockStatement()
         case .nop(_):
             op = Nop()
         }

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -752,6 +752,19 @@ class EndCodeString: Operation {
     }
 }
 
+/// Generates a block of instructions, which is lifted to a block statement.
+class BeginBlockStatement: Operation {
+    init() {
+        super.init(numInputs: 0, numOutputs: 0, attributes: [.isBlockBegin])
+    }
+}
+
+class EndBlockStatement: Operation {
+    init() {
+        super.init(numInputs: 0, numOutputs: 0, attributes: [.isBlockEnd])
+    }
+}
+
 /// Internal operations.
 ///
 /// These are never emitted through a code generator and are never mutated.

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -100,6 +100,8 @@ extension Operation {
             return endOp is EndTryCatch
         case is BeginCodeString:
             return endOp is EndCodeString
+        case is BeginBlockStatement:
+            return endOp is EndBlockStatement
         default:
             fatalError("Unknown block operation \(beginOp)")
         }

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -486,7 +486,15 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 let count = Int(pow(2, Double(codeStringNestingLevel)))-1
                 let escapeSequence = String(repeating: "\\", count: count)
                 w.emit("\(escapeSequence)`;")
-                
+
+            case is BeginBlockStatement:
+                w.emit("{")
+                w.increaseIndentionLevel()
+
+            case is EndBlockStatement:
+                w.decreaseIndentionLevel()
+                w.emit("}")
+
             case is Print:
                 w.emit("fuzzilli('FUZZILLI_PRINT', \(input(0)));")
                 

--- a/Sources/Fuzzilli/Minimization/BlockReducer.swift
+++ b/Sources/Fuzzilli/Minimization/BlockReducer.swift
@@ -47,6 +47,9 @@ struct BlockReducer: Reducer {
             case is BeginCodeString:
                 reduceCodeString(codestring: group, in: program, with: verifier)
 
+            case is BeginBlockStatement:
+                reduceGenericBlockGroup(group, in: program, with: verifier)
+
             default:
                 fatalError("Unknown block group: \(group.begin.operation.name)")
             }

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -1138,6 +1138,26 @@ public struct Fuzzilli_Protobuf_EndCodeString {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_BeginBlockStatement {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Fuzzilli_Protobuf_EndBlockStatement {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_Nop {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3005,6 +3025,44 @@ extension Fuzzilli_Protobuf_EndCodeString: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_EndCodeString, rhs: Fuzzilli_Protobuf_EndCodeString) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_BeginBlockStatement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".BeginBlockStatement"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_BeginBlockStatement, rhs: Fuzzilli_Protobuf_BeginBlockStatement) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_EndBlockStatement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".EndBlockStatement"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_EndBlockStatement, rhs: Fuzzilli_Protobuf_EndBlockStatement) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -321,5 +321,11 @@ message BeginCodeString {
 message EndCodeString {
 }
 
+message BeginBlockStatement {
+}
+
+message EndBlockStatement {  
+}
+
 message Nop {
 }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -726,6 +726,22 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {_uniqueStorage()._operation = .endCodeString(newValue)}
   }
 
+  public var beginBlockStatement: Fuzzilli_Protobuf_BeginBlockStatement {
+    get {
+      if case .beginBlockStatement(let v)? = _storage._operation {return v}
+      return Fuzzilli_Protobuf_BeginBlockStatement()
+    }
+    set {_uniqueStorage()._operation = .beginBlockStatement(newValue)}
+  }
+
+  public var endBlockStatement: Fuzzilli_Protobuf_EndBlockStatement {
+    get {
+      if case .endBlockStatement(let v)? = _storage._operation {return v}
+      return Fuzzilli_Protobuf_EndBlockStatement()
+    }
+    set {_uniqueStorage()._operation = .endBlockStatement(newValue)}
+  }
+
   public var nop: Fuzzilli_Protobuf_Nop {
     get {
       if case .nop(let v)? = _storage._operation {return v}
@@ -816,6 +832,8 @@ public struct Fuzzilli_Protobuf_Instruction {
     case comment(Fuzzilli_Protobuf_Comment)
     case beginCodeString(Fuzzilli_Protobuf_BeginCodeString)
     case endCodeString(Fuzzilli_Protobuf_EndCodeString)
+    case beginBlockStatement(Fuzzilli_Protobuf_BeginBlockStatement)
+    case endBlockStatement(Fuzzilli_Protobuf_EndBlockStatement)
     case nop(Fuzzilli_Protobuf_Nop)
 
   #if !swift(>=4.1)
@@ -899,6 +917,8 @@ public struct Fuzzilli_Protobuf_Instruction {
       case (.comment(let l), .comment(let r)): return l == r
       case (.beginCodeString(let l), .beginCodeString(let r)): return l == r
       case (.endCodeString(let l), .endCodeString(let r)): return l == r
+      case (.beginBlockStatement(let l), .beginBlockStatement(let r)): return l == r
+      case (.endBlockStatement(let l), .endBlockStatement(let r)): return l == r
       case (.nop(let l), .nop(let r)): return l == r
       default: return false
       }
@@ -1022,6 +1042,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     78: .same(proto: "comment"),
     81: .same(proto: "beginCodeString"),
     82: .same(proto: "endCodeString"),
+    83: .same(proto: "beginBlockStatement"),
+    84: .same(proto: "endBlockStatement"),
     64: .same(proto: "nop"),
   ]
 
@@ -1681,6 +1703,22 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           }
           try decoder.decodeSingularMessageField(value: &v)
           if let v = v {_storage._operation = .endCodeString(v)}
+        case 83:
+          var v: Fuzzilli_Protobuf_BeginBlockStatement?
+          if let current = _storage._operation {
+            try decoder.handleConflictingOneOf()
+            if case .beginBlockStatement(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._operation = .beginBlockStatement(v)}
+        case 84:
+          var v: Fuzzilli_Protobuf_EndBlockStatement?
+          if let current = _storage._operation {
+            try decoder.handleConflictingOneOf()
+            if case .endBlockStatement(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._operation = .endBlockStatement(v)}
         default: break
         }
       }
@@ -1851,6 +1889,10 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try visitor.visitSingularMessageField(value: v, fieldNumber: 81)
       case .endCodeString(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 82)
+      case .beginBlockStatement(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 83)
+      case .endBlockStatement(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 84)
       case nil: break
       }
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -103,6 +103,8 @@ message Instruction {
         Comment comment = 78;
         BeginCodeString beginCodeString = 81;
         EndCodeString endCodeString = 82;
+        BeginBlockStatement beginBlockStatement = 83;
+        EndBlockStatement endBlockStatement = 84;
         Nop nop = 64;
     }
 }

--- a/Sources/Fuzzilli/Protobuf/sync.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/sync.pb.swift
@@ -71,9 +71,9 @@ public struct Fuzzilli_Protobuf_FuzzerState {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var corpus: Data = Data()
+  public var corpus: Data = SwiftProtobuf.Internal.emptyData
 
-  public var evaluatorState: Data = Data()
+  public var evaluatorState: Data = SwiftProtobuf.Internal.emptyData
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -73,6 +73,7 @@ let codeGeneratorWeights = [
     "ContinueGenerator":                    5,
     "TryCatchGenerator":                    5,
     "ThrowGenerator":                       1,
+    "BlockStatmentGenerator":               3,
     
     // Special generators
     "WellKnownPropertyLoadGenerator":       5,

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -73,7 +73,7 @@ let codeGeneratorWeights = [
     "ContinueGenerator":                    5,
     "TryCatchGenerator":                    5,
     "ThrowGenerator":                       1,
-    "BlockStatementGenerator":              3,
+    "BlockStatementGenerator":              1,
     
     // Special generators
     "WellKnownPropertyLoadGenerator":       5,

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -73,7 +73,7 @@ let codeGeneratorWeights = [
     "ContinueGenerator":                    5,
     "TryCatchGenerator":                    5,
     "ThrowGenerator":                       1,
-    "BlockStatmentGenerator":               3,
+    "BlockStatementGenerator":              3,
     
     // Special generators
     "WellKnownPropertyLoadGenerator":       5,

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -237,6 +237,7 @@ class LifterTests: XCTestCase {
         """
         
         XCTAssertEqual(lifted_program, expected_program)
+    }
 
     func testBlockStatements(){
         let fuzzer = makeMockFuzzer()

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -61,6 +61,7 @@ extension LifterTests {
         ("testLiftingOptions", testLiftingOptions),
         ("testNestedCodeStrings", testNestedCodeStrings),
         ("testConsecutiveNestedCodeStrings", testConsecutiveNestedCodeStrings),
+        ("testBlockStatements", testBlockStatements),
     ]
 }
 


### PR DESCRIPTION
This generator will wrap JS instructions in a code block ```{ <instructions>... }```. This is an attempt to generate patterns such as the following [bug](https://bugs.chromium.org/p/project-zero/issues/detail?id=1665)
However, due to the semantic structure of FuzzIL programs (i.e. variable/function names are not reused) this probably won't generate many useful testcases that would trigger scoping bugs. Perhaps there is a way to improve this generator that I haven't considered.