### PR TITLE
Fix DeleteComputedProperty

### DIFF
--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -650,7 +650,7 @@ public class ProgramBuilder {
     }
     
     public func deleteComputedProperty(_ name: Variable, of object: Variable) {
-        perform(DeleteComputedProperty(), withInputs: [name, object])
+        perform(DeleteComputedProperty(), withInputs: [object, name])
     }
     
     @discardableResult


### PR DESCRIPTION
Now
```
let v0 = b.createObject(with: [:])
let v1 = b.loadString("a")
b.deleteComputedProperty(v1, of: v0)
```
lifts to `delete "a"[v0]` but it should be `delete v0["a"]`