### PR TITLE
Make InstanceOfGenerator type aware

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -224,8 +224,7 @@ public let CodeGenerators: [CodeGenerator] = [
         b.compare(type, rhs, with: .strictEqual)
     },
 
-    CodeGenerator("InstanceOfGenerator", input: .anything) { b, val in
-        let cls = b.randVar()
+    CodeGenerator("InstanceOfGenerator", inputs: (.anything, .function() | .constructor())) { b, val, cls in
         b.doInstanceOf(val, cls)
     },
 


### PR DESCRIPTION
Now `InstanceOfGenerator` can generate code like this `42 instanceof {}` which is rejected by engine with `TypeError`