### PR TITLE
Collect runtime types only on variable definition

### DIFF
--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -219,13 +219,11 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 let dest = MemberExpression.new() <> input(0) <> "." <> op.propertyName
                 let expr = AssignmentExpression.new() <> dest <> " = " <> input(1)
                 w.emit(expr)
-                maybeUpdateType(instr.input(0))
                 
             case let op as DeleteProperty:
                 let target = MemberExpression.new() <> input(0) <> "." <> op.propertyName
                 let expr = UnaryExpression.new() <> "delete " <> target
                 w.emit(expr)
-                maybeUpdateType(instr.input(0))
                 
             case let op as LoadElement:
                 output = MemberExpression.new() <> input(0) <> "[" <> op.index <> "]"
@@ -234,13 +232,11 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 let dest = MemberExpression.new() <> input(0) <> "[" <> op.index <> "]"
                 let expr = AssignmentExpression.new() <> dest <> " = " <> input(1)
                 w.emit(expr)
-                maybeUpdateType(instr.input(0))
                 
             case let op as DeleteElement:
                 let target = MemberExpression.new() <> input(0) <> "[" <> op.index <> "]"
                 let expr = UnaryExpression.new() <> "delete " <> target
                 w.emit(expr)
-                maybeUpdateType(instr.input(0))
                 
             case is LoadComputedProperty:
                 output = MemberExpression.new() <> input(0) <> "[" <> input(1).text <> "]"
@@ -249,13 +245,11 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 let dest = MemberExpression.new() <> input(0) <> "[" <> input(1).text <> "]"
                 let expr = AssignmentExpression.new() <> dest <> " = " <> input(2)
                 w.emit(expr)
-                maybeUpdateType(instr.input(0))
                 
             case is DeleteComputedProperty:
                 let target = MemberExpression.new() <> input(0) <> "[" <> input(1).text <> "]"
                 let expr = UnaryExpression.new() <> "delete " <> target
                 w.emit(expr)
-                maybeUpdateType(instr.input(0))
                 
             case is TypeOf:
                 output = UnaryExpression.new() <> "typeof " <> input(0)
@@ -348,11 +342,9 @@ public class JavaScriptLifter: ComponentBase, Lifter {
                 
             case is Dup:
                 w.emit("\(decl(instr.output)) = \(input(0));")
-                maybeUpdateType(instr.output)
                 
             case is Reassign:
                 w.emit("\(instr.input(0)) = \(input(1));")
-                maybeUpdateType(instr.input(0))
                 
             case let op as Compare:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)
@@ -438,7 +430,6 @@ public class JavaScriptLifter: ComponentBase, Lifter {
             case is BeginForIn:
                 w.emit("for (\(decl(instr.innerOutput)) in \(input(0))) {")
                 w.increaseIndentionLevel()
-                maybeUpdateType(instr.innerOutput)
                 
             case is EndForIn:
                 w.decreaseIndentionLevel()

--- a/Sources/Fuzzilli/Mutators/InputMutator.swift
+++ b/Sources/Fuzzilli/Mutators/InputMutator.swift
@@ -23,7 +23,7 @@ public class InputMutator: BaseInstructionMutator {
     }
     
     public override func mutate(_ instr: Instruction, _ b: ProgramBuilder) {
-        var inouts = b.adopt(instr.inouts, keepTypes: false)
+        var inouts = b.adopt(instr.inouts)
         
         // Replace one input
         let selectedInput = Int.random(in: 0..<instr.numInputs)


### PR DESCRIPTION
Should help with operations `StoreProperty` & `DeleteProperty` as currently type collection just unions this information away.
This PR modifies it in a way `AbstractInterpreter` adopts runtimeType at definition and handles these intstructions on its own.

Also should save time on `Dup` or `Reassign` operations.