### PR TITLE
Add diagnostics mode

### DIFF
--- a/Sources/Fuzzilli/Configuration.swift
+++ b/Sources/Fuzzilli/Configuration.swift
@@ -68,6 +68,9 @@ public struct Configuration {
     public let useAbstractInterpretation: Bool
 
     public let collectRuntimeTypes: Bool
+
+    /// Enable the saving of programs that failed or timed-out during execution.
+    public let diagnostics: Bool
     
     public init(timeout: UInt32 = 250,
                 skipStartupTests: Bool = false,
@@ -80,7 +83,8 @@ public struct Configuration {
                 minimizationLimit: UInt = 0,
                 dropoutRate: Double = 0.01,
                 useAbstractInterpretation: Bool = true,
-                collectRuntimeTypes: Bool = false) {
+                collectRuntimeTypes: Bool = false,
+                diagnostics: Bool = false) {
         self.timeout = timeout
         self.speedTestMode = speedTestMode
         self.logLevel = logLevel
@@ -92,5 +96,6 @@ public struct Configuration {
         self.minimizationLimit = minimizationLimit
         self.useAbstractInterpretation = useAbstractInterpretation
         self.collectRuntimeTypes = collectRuntimeTypes
+        self.diagnostics = diagnostics
     }
 }

--- a/Sources/Fuzzilli/Core/Events.swift
+++ b/Sources/Fuzzilli/Core/Events.swift
@@ -64,6 +64,9 @@ public class Events {
     /// Signals that a new interesting program has been found, after the program has been minimized.
     public let InterestingProgramFound = Event<(program: Program, isImported: Bool, newTypeCollectionRun: Bool)>()
 
+    /// Signals that the REPRL instance encountered an error with the attached log of scripts.
+    public let REPRLFail = Event<[String]>()
+
     /// Signals that a program is about to be executed.
     public let PreExecute = Event<Program>()
     

--- a/Sources/Fuzzilli/Core/Events.swift
+++ b/Sources/Fuzzilli/Core/Events.swift
@@ -64,8 +64,8 @@ public class Events {
     /// Signals that a new interesting program has been found, after the program has been minimized.
     public let InterestingProgramFound = Event<(program: Program, isImported: Bool, newTypeCollectionRun: Bool)>()
 
-    /// Signals that the REPRL instance encountered an error with the attached log of scripts.
-    public let REPRLFail = Event<[String]>()
+    /// Signals a diagnostics event
+    public let DiagnosticsEvent = Event<(name: String, content: String)>()
 
     /// Signals that a program is about to be executed.
     public let PreExecute = Event<Program>()

--- a/Sources/Fuzzilli/Execution/REPRL.swift
+++ b/Sources/Fuzzilli/Execution/REPRL.swift
@@ -37,7 +37,7 @@ public class REPRL: ComponentBase, ScriptRunner {
 
     /// Buffer to hold scripts, this lets us debug issues that arise if
     /// previous scripts corrupted any state which is discovered in
-    /// future executions.
+    /// future executions. This is only used if diagnostics mode is enabled.
     private var scriptBuffer = String()
 
     public init(executable: String, processArguments: [String], processEnvironment: [String: String]) {
@@ -107,7 +107,6 @@ public class REPRL: ComponentBase, ScriptRunner {
             if status < 0 {
                 logger.warning("Script execution failed: \(String(cString: reprl_get_last_error(reprlContext))). Retrying in 1 second...")
                 if fuzzer.config.diagnostics {
-                    // Log the buffer to disk
                     fuzzer.dispatchEvent(fuzzer.events.DiagnosticsEvent, data: (name: "REPRLFail", content: scriptBuffer))
                 }
                 sleep(1)

--- a/Sources/Fuzzilli/Modules/Storage.swift
+++ b/Sources/Fuzzilli/Modules/Storage.swift
@@ -24,7 +24,7 @@ public class Storage: Module {
     private let stateFile: String
     private let failedDir: String
     private let timeOutDir: String
-    private let REPRLFailDir: String
+    private let DiagnosticsDir: String
 
     private let stateExportInterval: Double?
     private let statisticsExportInterval: Double?
@@ -41,7 +41,7 @@ public class Storage: Module {
         self.timeOutDir = storageDir + "/timeouts"
         self.statisticsDir = storageDir + "/stats"
         self.stateFile = storageDir + "/state.json"
-        self.REPRLFailDir = storageDir + "/reprl_fails"
+        self.DiagnosticsDir = storageDir + "/diagnostics"
 
         self.stateExportInterval = stateExportInterval
         self.statisticsExportInterval = statisticsExportInterval
@@ -59,7 +59,7 @@ public class Storage: Module {
             if fuzzer.config.diagnostics {
                 try FileManager.default.createDirectory(atPath: failedDir, withIntermediateDirectories: true)
                 try FileManager.default.createDirectory(atPath: timeOutDir, withIntermediateDirectories: true)
-                try FileManager.default.createDirectory(atPath: REPRLFailDir, withIntermediateDirectories: true)
+                try FileManager.default.createDirectory(atPath: DiagnosticsDir, withIntermediateDirectories: true)
             }
         } catch {
             logger.fatal("Failed to create storage directories. Is \(storageDir) writable by the current user?")
@@ -79,14 +79,9 @@ public class Storage: Module {
 
         if fuzzer.config.diagnostics {
             fuzzer.registerEventListener(for: fuzzer.events.DiagnosticsEvent) { ev in
-                switch ev.name {
-                    case "REPRLFail":
-                        let filename = "/reprllog_\(String(currentMillis()))"
-                        let fileURL = URL(fileURLWithPath: self.REPRLFailDir + filename)
-                        self.storeProgram(ev.content, to: fileURL)
-                    default:
-                        self.logger.fatal("Unhandled diagnostics event: \(ev.name)")
-                }
+                let filename = "/\(ev.name)_\(String(currentMillis()))"
+                let fileURL = URL(fileURLWithPath: self.DiagnosticsDir + filename)
+                self.storeProgram(ev.content, to: fileURL)
             }
 
             fuzzer.registerEventListener(for: fuzzer.events.InvalidProgramFound) { program in

--- a/Sources/Fuzzilli/Modules/Storage.swift
+++ b/Sources/Fuzzilli/Modules/Storage.swift
@@ -24,7 +24,7 @@ public class Storage: Module {
     private let stateFile: String
     private let failedDir: String
     private let timeOutDir: String
-    private let DiagnosticsDir: String
+    private let diagnosticsDir: String
 
     private let stateExportInterval: Double?
     private let statisticsExportInterval: Double?
@@ -41,7 +41,7 @@ public class Storage: Module {
         self.timeOutDir = storageDir + "/timeouts"
         self.statisticsDir = storageDir + "/stats"
         self.stateFile = storageDir + "/state.json"
-        self.DiagnosticsDir = storageDir + "/diagnostics"
+        self.diagnosticsDir = storageDir + "/diagnostics"
 
         self.stateExportInterval = stateExportInterval
         self.statisticsExportInterval = statisticsExportInterval
@@ -59,7 +59,7 @@ public class Storage: Module {
             if fuzzer.config.diagnostics {
                 try FileManager.default.createDirectory(atPath: failedDir, withIntermediateDirectories: true)
                 try FileManager.default.createDirectory(atPath: timeOutDir, withIntermediateDirectories: true)
-                try FileManager.default.createDirectory(atPath: DiagnosticsDir, withIntermediateDirectories: true)
+                try FileManager.default.createDirectory(atPath: diagnosticsDir, withIntermediateDirectories: true)
             }
         } catch {
             logger.fatal("Failed to create storage directories. Is \(storageDir) writable by the current user?")
@@ -80,7 +80,7 @@ public class Storage: Module {
         if fuzzer.config.diagnostics {
             fuzzer.registerEventListener(for: fuzzer.events.DiagnosticsEvent) { ev in
                 let filename = "/\(ev.name)_\(String(currentMillis()))"
-                let fileURL = URL(fileURLWithPath: self.DiagnosticsDir + filename)
+                let fileURL = URL(fileURLWithPath: self.diagnosticsDir + filename)
                 self.storeProgram(ev.content, to: fileURL)
             }
 

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -55,6 +55,8 @@ Options:
                                   Configuration.swift for more details.
     --collectRuntimeTypes       : Collect runtime types of variables in program when interesting one found.
                                   Currently in development.
+    --diagnostics               : Enable saving of programs that failed or timed-out during execution. Also tracks
+                                  executions on the current REPRL instance.
 """)
     exit(0)
 }
@@ -90,6 +92,7 @@ let stateImportFile = args["--importState"]
 let disableAbstractInterpreter = args.has("--noAbstractInterpretation")
 let dontFuzz = args.has("--dontFuzz")
 let collectRuntimeTypes = args.has("--collectRuntimeTypes")
+let diagnostics = args.has("--diagnostics")
 
 let logLevelByName: [String: LogLevel] = ["verbose": .verbose, "info": .info, "warning": .warning, "error": .error, "fatal": .fatal]
 guard let logLevel = logLevelByName[logLevelName] else {
@@ -156,7 +159,8 @@ let config = Configuration(timeout: UInt32(timeout),
                            isFuzzing: !dontFuzz,
                            minimizationLimit: minimizationLimit,
                            useAbstractInterpretation: !disableAbstractInterpreter,
-                           collectRuntimeTypes: collectRuntimeTypes)
+                           collectRuntimeTypes: collectRuntimeTypes,
+                           diagnostics: diagnostics)
 
 // A script runner to execute JavaScript code in an instrumented JS engine.
 let runner = REPRL(executable: jsShellPath, processArguments: profile.processArguments, processEnvironment: profile.processEnv)


### PR DESCRIPTION
Add a diagnostics mode to save executions that failed or timed-out.
This allows analysis of the output of the fuzzer.
Diagnostics mode also saves all executions made on a REPRL instance
to find scripts that may corrupt the state of the REPRL and saves all
executed scripts if it detects such a REPRL failure.