### PR TITLE
Collect runtime types per instruction

### DIFF
--- a/Sources/Fuzzilli/Core/Corpus.swift
+++ b/Sources/Fuzzilli/Core/Corpus.swift
@@ -122,9 +122,13 @@ public class Corpus: ComponentBase, Collection {
 
     /// Change type extensions for cached ones to save memory
     private func deduplicateTypeExtensions(in program: Program) {
-        var deduplicatedRuntimeTypes = VariableMap<Type>()
-        for (variable, runtimeType) in program.runtimeTypes {
-            deduplicatedRuntimeTypes[variable] = runtimeType.uniquify(with: &typeExtensionDeduplicationSet)
+        var deduplicatedRuntimeTypes = VariableMap<[Int: Type]>()
+        for (variable, instrMap) in program.runtimeTypes {
+            // Initialize structure for storing per instruction type
+            deduplicatedRuntimeTypes[variable] = [:]
+            for (instrIndex, runtimeType) in instrMap {
+                deduplicatedRuntimeTypes[variable]![instrIndex] = runtimeType.uniquify(with: &typeExtensionDeduplicationSet)
+            }
         }
         program.runtimeTypes = deduplicatedRuntimeTypes
     }

--- a/Sources/Fuzzilli/Lifting/TypeCollectionAnalyzer.swift
+++ b/Sources/Fuzzilli/Lifting/TypeCollectionAnalyzer.swift
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Determine what variable types we should collect given instruction
+struct TypeCollectionAnalyzer {
+    // Special properties which significantly change variable type
+    // We should recollect type if we change them
+    let specialProperties = ["__proto__"]
+
+    func analyze(_ instr: Instruction) -> [Variable] {
+        switch instr.operation {
+            case is LoadInteger, is LoadBigInt, is LoadFloat, is LoadBoolean, is LoadNull, is LoadUndefined,
+                 is TypeOf, is InstanceOf, is In, is Dup, is Reassign, is Compare, is BeginForIn:
+                // No need to collect types for instructions interpreter can handle
+                return []
+            case is BeginAnyFunctionDefinition:
+                // No type collection on function definitions for now
+                return []
+            case let op as StoreProperty where specialProperties.contains(op.propertyName):
+                // Recollect type of this variable, because major change happened
+                return [instr.input(0)]
+            default:
+                // By default, collect types for all outputs of an instruction
+                return Array(instr.allOutputs)
+        }
+    }
+}

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -24,31 +24,24 @@ public class OperationMutator: BaseInstructionMutator {
 
     public override func mutate(_ instr: Instruction, _ b: ProgramBuilder) {
         var newOp: Operation
-        var keepTypes = false
         
         switch instr.operation {
         case is LoadInteger:
             newOp = LoadInteger(value: b.genInt())
-            keepTypes = true
         case is LoadBigInt:
             newOp = LoadBigInt(value: b.genInt())
-            keepTypes = true
         case is LoadFloat:
             newOp = LoadFloat(value: b.genFloat())
-            keepTypes = true
         case is LoadString:
             newOp = LoadString(value: b.genString())
-            keepTypes = true
         case let op as LoadRegExp:
             if probability(0.5) {
                 newOp = LoadRegExp(value: b.genRegExp(), flags: op.flags)
             } else {
                 newOp = LoadRegExp(value: op.value, flags: b.genRegExpFlags())
             }
-            keepTypes = true
         case let op as LoadBoolean:
             newOp = LoadBoolean(value: !op.value)
-            keepTypes = true
         case let op as CreateObject:
             var propertyNames = op.propertyNames
             assert(!propertyNames.isEmpty)          // Otherwise operation would not be parametric
@@ -97,7 +90,6 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = BinaryOperation(chooseUniform(from: allBinaryOperators))
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))
-            keepTypes = true
         case is LoadFromScope:
             newOp = LoadFromScope(id: b.genPropertyNameForRead())
         case is StoreToScope:
@@ -109,7 +101,6 @@ public class OperationMutator: BaseInstructionMutator {
         case let op as BeginFor:
             if probability(0.5) {
                 newOp = BeginFor(comparator: chooseUniform(from: allComparators), op: op.op)
-                keepTypes = true
             } else {
                 newOp = BeginFor(comparator: op.comparator, op: chooseUniform(from: allBinaryOperators))
             }
@@ -117,6 +108,6 @@ public class OperationMutator: BaseInstructionMutator {
             fatalError("[OperationMutator] Unhandled Operation: \(type(of: instr.operation))")
         }
 
-        b.adopt(Instruction(operation: newOp, inouts: instr.inouts), keepTypes: keepTypes)
+        b.adopt(Instruction(operation: newOp, inouts: instr.inouts), keepTypes: false)
     }
 }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -951,6 +951,18 @@ public struct Fuzzilli_Protobuf_Instruction {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
+public struct Fuzzilli_Protobuf_TypeMap {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var typeMap: Dictionary<UInt32,Fuzzilli_Protobuf_Type> = [:]
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_Program {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -958,7 +970,7 @@ public struct Fuzzilli_Protobuf_Program {
 
   public var instructions: [Fuzzilli_Protobuf_Instruction] = []
 
-  public var runtimeTypes: Dictionary<UInt32,Fuzzilli_Protobuf_Type> = [:]
+  public var runtimeTypes: Dictionary<UInt32,Fuzzilli_Protobuf_TypeMap> = [:]
 
   public var typeCollectionStatus: Fuzzilli_Protobuf_TypeCollectionStatus = .success
 
@@ -1957,6 +1969,35 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
+extension Fuzzilli_Protobuf_TypeMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TypeMap"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "typeMap"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_Type>.self, value: &self.typeMap)
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.typeMap.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_Type>.self, value: self.typeMap, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_TypeMap, rhs: Fuzzilli_Protobuf_TypeMap) -> Bool {
+    if lhs.typeMap != rhs.typeMap {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Program"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1969,7 +2010,7 @@ extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._Messa
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
       case 1: try decoder.decodeRepeatedMessageField(value: &self.instructions)
-      case 2: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_Type>.self, value: &self.runtimeTypes)
+      case 2: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_TypeMap>.self, value: &self.runtimeTypes)
       case 3: try decoder.decodeSingularEnumField(value: &self.typeCollectionStatus)
       default: break
       }
@@ -1981,7 +2022,7 @@ extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._Messa
       try visitor.visitRepeatedMessageField(value: self.instructions, fieldNumber: 1)
     }
     if !self.runtimeTypes.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_Type>.self, value: self.runtimeTypes, fieldNumber: 2)
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_TypeMap>.self, value: self.runtimeTypes, fieldNumber: 2)
     }
     if self.typeCollectionStatus != .success {
       try visitor.visitSingularEnumField(value: self.typeCollectionStatus, fieldNumber: 3)

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -119,8 +119,12 @@ enum TypeCollectionStatus {
     NOTATTEMPTED = 3;
 }
 
+message TypeMap {
+  map<uint32, Type> typeMap = 1;
+}
+
 message Program {
     repeated Instruction instructions = 1;
-    map<uint32, Type> runtimeTypes = 2;
+    map<uint32, TypeMap> runtimeTypes = 2;
     TypeCollectionStatus typeCollectionStatus = 3;
 }

--- a/Sources/JS/initTypeCollection.js
+++ b/Sources/JS/initTypeCollection.js
@@ -64,7 +64,7 @@ Type.prototype.collectProps = function(obj) {
     }
 }
 
-// variableNumber: Type
+// variableNumber: {instructionNumber: Type}
 var types = {}
 function getCurrentType(value){
     try {
@@ -106,9 +106,12 @@ function getCurrentType(value){
     // Set unknown if no type was matched or error occurred
     return new Type(baseTypes.unknown)
 }
-function updateType(number, value) {
+function updateType(varNumber, instrIndex, value) {
     var currentType = getCurrentType(value)
 
-    if (types[number] == null) types[number] = currentType
-    else types[number] = types[number].union(currentType)
+    // Initialize structure for this variable if it is not already
+    if (types[varNumber] == null) types[varNumber] = {}
+
+    if (types[varNumber][instrIndex] == null) types[varNumber][instrIndex] = currentType
+    else types[varNumber][instrIndex] = types[varNumber][instrIndex].union(currentType)
 }

--- a/Sources/JS/initTypeCollection.swift
+++ b/Sources/JS/initTypeCollection.swift
@@ -108,10 +108,13 @@ function getCurrentType(value){
     // Set unknown if no type was matched or error occurred
     return new Type(baseTypes.unknown)
 }
-function updateType(number, value) {
+function updateType(varNumber, instrIndex, value) {
     var currentType = getCurrentType(value)
 
-    if (types[number] == null) types[number] = currentType
-    else types[number] = types[number].union(currentType)
+    // Initialize structure for this variable if it is not already
+    if (types[varNumber] == null) types[varNumber] = {}
+
+    if (types[varNumber][instrIndex] == null) types[varNumber][instrIndex] = currentType
+    else types[varNumber][instrIndex] = types[varNumber][instrIndex].union(currentType)
 }
 """

--- a/Sources/JS/printTypes.js
+++ b/Sources/JS/printTypes.js
@@ -15,6 +15,13 @@ var varNumbers = getObjectKeys(types)
 // Do not use for in to avoid iterating over prototype properties
 for (var i=0;i<varNumbers.length;i++) {
     var varNumber = varNumbers[i]
+    var instrNumbers = getObjectKeys(types[varNumber])
     fuzzilli('FUZZILLI_PRINT', varNumber)
-    fuzzilli('FUZZILLI_PRINT', jsonStringify(types[varNumber]))
+    fuzzilli('FUZZILLI_PRINT', instrNumbers.length)
+
+    for (var j=0;j<instrNumbers.length;j++) {
+        var instrNumber = instrNumbers[j]
+        fuzzilli('FUZZILLI_PRINT', instrNumber)
+        fuzzilli('FUZZILLI_PRINT', jsonStringify(types[varNumber][instrNumber]))
+    }
 }

--- a/Sources/JS/printTypes.swift
+++ b/Sources/JS/printTypes.swift
@@ -17,7 +17,14 @@ public let printTypesScript = """
 var varNumbers = getObjectKeys(types)
 for (var i=0;i<varNumbers.length;i++) {
     var varNumber = varNumbers[i]
+    var instrNumbers = getObjectKeys(types[varNumber])
     fuzzilli('FUZZILLI_PRINT', varNumber)
-    fuzzilli('FUZZILLI_PRINT', jsonStringify(types[varNumber]))
+    fuzzilli('FUZZILLI_PRINT', instrNumbers.length)
+
+    for (var j=0;j<instrNumbers.length;j++) {
+        var instrNumber = instrNumbers[j]
+        fuzzilli('FUZZILLI_PRINT', instrNumber)
+        fuzzilli('FUZZILLI_PRINT', jsonStringify(types[varNumber][instrNumber]))
+    }
 }
 """

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -63,7 +63,6 @@ extension MutationsTests {
     // to regenerate.
     static let __allTests__MutationsTests = [
         ("testInputMutatorRuntimeTypes", testInputMutatorRuntimeTypes),
-        ("testOperationMutatorRuntimeTypes", testOperationMutatorRuntimeTypes),
         ("testPrepareMutationRuntimeTypes", testPrepareMutationRuntimeTypes),
     ]
 }


### PR DESCRIPTION
* Adjust runtimeTypes map to store types per (variable, instruction)
* Stop adopting types fom `OperationMutator` (Cases when we did can handle `AbstractInterpreter`)
* Add type collection on changing `__proto__`
 