### PR TITLE
Programs are now immutable

### DIFF
--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -43,7 +43,7 @@ public struct AbstractInterpreter {
     
     /// Abstractly execute the given instruction, thus updating type information.
     public mutating func execute(_ instr: Instruction) {
-        switch instr.operation {
+        switch instr.op {
         case is BeginAnyFunctionDefinition:
             stack.append(currentState)
         case is EndAnyFunctionDefinition:
@@ -202,7 +202,7 @@ public struct AbstractInterpreter {
     }
     
     private mutating func executeEffects(_ instr: Instruction) {
-        switch instr.operation {
+        switch instr.op {
             
         case let op as LoadBuiltin:
             set(instr.output, environment.type(ofBuiltin: op.builtinName))
@@ -390,7 +390,7 @@ public struct AbstractInterpreter {
             set(instr.output, .string)
 
         default:
-            assert(!instr.hasOutput)
+            assert(!instr.hasOutputs)
         }
         
         // Variables must not be .anything or .nothing. For variables that can be anything, .unknown is the correct type.

--- a/Sources/Fuzzilli/FuzzIL/Code.swift
+++ b/Sources/Fuzzilli/FuzzIL/Code.swift
@@ -1,0 +1,239 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Code: a sequence of instructions. Forms the basis of Programs.
+public struct Code: Collection {
+    public typealias Element = Instruction
+
+    /// Code is just a linear sequence of instructions
+    private var instructions = [Instruction]()
+
+    /// Creates an empty code instance.
+    public init() {}
+
+    /// Creates a code instance containing the given instructions.
+    public init(_ instructions: [Instruction]) {
+        for instr in instructions {
+            append(instr)
+        }
+    }
+
+    /// The number of instructions.
+    public var count: Int {
+        return instructions.count
+    }
+
+    /// The index of the first instruction, always 0.
+    public var startIndex: Int {
+        return 0
+    }
+
+    /// The index of the last instruction plus one.
+    public var endIndex: Int {
+        return count
+    }
+
+    /// Advances the given index by one. Simply returns the argument plus 1.
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+
+    /// Access the ith instruction in this code.
+    public subscript(i: Int) -> Instruction {
+        get {
+            instructions[i]
+        }
+        set {
+            instructions[i] = Instruction(newValue.op, inouts: newValue.inouts, index: i)
+        }
+    }
+    
+    /// Returns the instruction after the given one, if it exists.
+    public func after(_ instr: Instruction) -> Instruction? {
+        let idx = instr.index + 1
+        return idx < endIndex ? self[idx] : nil
+    }
+    
+    /// Returns the instruction before the given one, if it exists.
+    public func before(_ instr: Instruction) -> Instruction? {
+        let idx = instr.index - 1
+        return idx >= 0 ? self[idx] : nil
+    }
+
+    /// The last instruction in this code.
+    public var lastInstruction: Instruction {
+        return instructions.last!
+    }
+
+    /// Returns the instructions in this code in reversed order.
+    public func reversed() -> ReversedCollection<Array<Instruction>> {
+        return instructions.reversed()
+    }
+
+    /// Enumerates the instructions in this code.
+    public func enumerated() -> EnumeratedSequence<Array<Instruction>> {
+        return instructions.enumerated()
+    }
+
+    /// Appends the given instruction to this code.
+    public mutating func append(_ instr: Instruction) {
+        instructions.append(Instruction(instr.op, inouts: instr.inouts, index: count))
+    }
+
+    /// Removes all instructions in this code.
+    public mutating func removeAll() {
+        instructions.removeAll()
+    }
+
+    /// Removes the last instruction in this code.
+    public mutating func removeLast(_ n: Int = 1) {
+        instructions.removeLast(n)
+    }
+    
+    /// Checks whether the given instruction belongs to this code.
+    public func contains(_ instr: Instruction) -> Bool {
+        let idx = instr.index
+        guard idx >= 0 && idx < count else { return false }
+        return instr.op === self[idx].op && instr.inouts == self[idx].inouts
+    }
+
+    /// Replaces an instruction with a different one.
+    ///
+    /// - Parameters:
+    ///   - instr: The instruction to replace.
+    ///   - newInstr: The new instruction.
+    public mutating func replace(_ instr: Instruction, with newInstr: Instruction) {
+        assert(contains(instr))
+        self[instr.index] = newInstr
+    }
+    
+    /// Computes the next free variable in this code.
+    public func nextFreeVariable() -> Variable {
+        precondition(isStaticallyValid())
+        for instr in instructions.reversed() {
+            if let r = instr.allOutputs.max() {
+                return Variable(number: r.number + 1)
+            }
+        }
+        return Variable(number: 0)
+    }
+    
+    /// Removes nops and renumbers variables so that their numbers are contiguous.
+    public mutating func normalize() {
+        precondition(isStaticallyValid())
+        
+        var writeIndex = 0
+        var numVariables = 0
+        var varMap = VariableMap<Variable>()
+
+        for instr in self {
+            if instr.op is Nop {
+                continue
+            }
+
+            for output in instr.allOutputs {
+                // Must create a new variable
+                assert(!varMap.contains(output))
+                let mappedVar = Variable(number: numVariables)
+                varMap[output] = mappedVar
+                numVariables += 1
+            }
+
+            let inouts = instr.inouts.map({ varMap[$0]! })
+
+            self[writeIndex] = Instruction(instr.op, inouts: inouts)
+            writeIndex += 1
+        }
+
+        removeLast(count - writeIndex)
+    }
+    
+    /// Checks if this code is statically valid, i.e. can be used as a Program.
+    public func check() throws {
+        var definedVariables = VariableMap<Int>()
+        var scopeCounter = 0
+        var visibleScopes = [scopeCounter]
+        var blockHeads = [Operation]()
+
+        for (idx, instr) in instructions.enumerated() {
+            guard idx == instr.index else {
+                throw FuzzilliError.codeVerificationError("instruction \(idx) has wrong index \(String(describing: instr.index))")
+            }
+
+            // Ensure all input variables are valid and have been defined
+            for input in instr.inputs {
+                guard let definingScope = definedVariables[input] else {
+                    throw FuzzilliError.codeVerificationError("variable \(input) was never defined")
+                }
+                guard visibleScopes.contains(definingScope) else {
+                    throw FuzzilliError.codeVerificationError("variable \(input) is not visible anymore")
+                }
+            }
+
+            // Block and scope management (1)
+            if instr.isBlockEnd {
+                guard let blockBegin = blockHeads.popLast() else {
+                    throw FuzzilliError.codeVerificationError("block was never started")
+                }
+                guard instr.op.isMatchingEnd(for: blockBegin) else {
+                    throw FuzzilliError.codeVerificationError("block end does not match block start")
+                }
+                visibleScopes.removeLast()
+            }
+
+            // Ensure output variables don't exist yet
+            for output in instr.outputs {
+                guard !definedVariables.contains(output) else {
+                    throw FuzzilliError.codeVerificationError("variable \(output) was already defined")
+                }
+                // Verify that nop outputs are not be used by other instruction
+                let scope = instr.op is Nop ? -1 : visibleScopes.last!
+                definedVariables[output] = scope
+            }
+
+            // Block and scope management (2)
+            if instr.isBlockBegin {
+                scopeCounter += 1
+                visibleScopes.append(scopeCounter)
+                blockHeads.append(instr.op)
+            }
+
+            // Ensure inner output variables don't exist yet
+            for output in instr.innerOutputs {
+                guard !definedVariables.contains(output) else {
+                    throw FuzzilliError.codeVerificationError("variable \(output) was already defined")
+                }
+                definedVariables[output] = visibleScopes.last!
+            }
+        }
+
+        // Ensure that variable numbers are contiguous
+        guard !definedVariables.hasHoles() else {
+            throw FuzzilliError.codeVerificationError("Variable numbers are not contiguous")
+        }
+    }
+
+    /// Returns true if this code is valid, false otherwise.
+    public func isStaticallyValid() -> Bool {
+        do {
+            try check()
+            return true
+        } catch {
+            return false
+        }
+    }
+    
+    // This restriction arises from the fact that variables and instruction indices are stored internally as UInt16
+    public static let maxNumberOfVariables = 0x10000
+}

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -65,12 +65,6 @@ public class Operation {
     }
 }
 
-class Nop: Operation {    
-    init() {
-        super.init(numInputs: 0, numOutputs: 0, attributes: [.isPrimitive])
-    }
-}
-
 class LoadInteger: Operation {
     let value: Int64
     
@@ -605,6 +599,18 @@ class StoreToScope: Operation {
     }
 }
 
+class Nop: Operation {
+    // NOPs can have "pseudo" outputs. These should not be used by other instructions
+    // and they should not be present in the lifted code, i.e. a NOP should just be
+    // ignored during lifting.
+    // These pseudo outputs are used to simplify some algorithms, e.g. minimization,
+    // which needs to replace instructions with NOPs while keeping the variable numbers
+    // contiguous. They can also serve as placeholders for future instructions.
+    init(numOutputs: Int = 0) {
+        super.init(numInputs: 0, numOutputs: numOutputs, attributes: [.isPrimitive])
+    }
+}
+
 ///
 /// Control Flow
 ///
@@ -780,10 +786,7 @@ class EndBlockStatement: Operation {
 
 /// Internal operations.
 ///
-/// These are never emitted through a code generator and are never mutated.
-/// In fact, these will never appear in a program that has been added to the corpus.
-/// Instead they are used in programs emitted by the fuzzer backend for various
-/// internal purposes, e.g. to retrieve type information for a variable.
+/// These can be used for internal fuzzer operations but will not appear in the corpus.
 class InternalOperation: Operation {
     init(numInputs: Int) {
         super.init(numInputs: numInputs, numOutputs: 0, attributes: [.isInternal])
@@ -797,26 +800,6 @@ class Print: InternalOperation {
     }
 }
 
-/// Writes the type of the input value to the output stream.
-class InspectType: InternalOperation {
-    init() {
-        super.init(numInputs: 1)
-    }
-}
-
-/// Writes the properties and methods of the input value to the output stream.
-class InspectValue: InternalOperation {
-    init() {
-        super.init(numInputs: 1)
-    }
-}
-
-/// Writes the globally accessible objects to the output stream.
-class EnumerateBuiltins: InternalOperation {
-    init() {
-        super.init(numInputs: 0)
-    }
-}
 
 // Expose the name of an operation as instance and class variable
 extension Operation {

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -54,7 +54,7 @@ extension Instruction {
     func mayMutate(_ v: Variable) -> Bool {
         for (idx, input) in inputs.enumerated() {
             if input == v {
-                if operation.mayMutate(input: idx) {
+                if op.mayMutate(input: idx) {
                     return true
                 }
             }
@@ -66,7 +66,7 @@ extension Instruction {
     func mayMutate(_ vars: VariableSet) -> Bool {
         for (idx, input) in inputs.enumerated() {
             if vars.contains(input) {
-                if operation.mayMutate(input: idx) {
+                if op.mayMutate(input: idx) {
                     return true
                 }
             }
@@ -78,7 +78,7 @@ extension Instruction {
     func reassigns(_ v: Variable) -> Bool {
         for (idx, input) in inputs.enumerated() {
             if input == v {
-                if operation.reassigns(input: idx) {
+                if op.reassigns(input: idx) {
                     return true
                 }
             }

--- a/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
+++ b/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
@@ -901,10 +901,10 @@ public func => (params: [Type], returnType: Type) -> FunctionSignature {
 }
 
 extension Type: ProtobufConvertible {
-    typealias ProtoType = Fuzzilli_Protobuf_Type
+    typealias ProtobufType = Fuzzilli_Protobuf_Type
     
-    func asProtobuf() -> ProtoType {
-        return ProtoType.with {
+    func asProtobuf() -> ProtobufType {
+        return ProtobufType.with {
             $0.definiteType = definiteType.rawValue
             $0.possibleType = possibleType.rawValue
             if let typeExtension = ext {
@@ -920,7 +920,7 @@ extension Type: ProtobufConvertible {
         }
     }
 
-    init(from proto: ProtoType) throws {
+    init(from proto: ProtobufType) throws {
         var ext: TypeExtension? = nil
         
         if !proto.properties.isEmpty || !proto.methods.isEmpty || !proto.group.isEmpty || proto.hasSignature {
@@ -937,16 +937,16 @@ extension Type: ProtobufConvertible {
 }
 
 extension FunctionSignature: ProtobufConvertible {
-    typealias ProtoType = Fuzzilli_Protobuf_FunctionSignature
+    typealias ProtobufType = Fuzzilli_Protobuf_FunctionSignature
     
-    func asProtobuf() -> ProtoType {
-        return ProtoType.with {
+    func asProtobuf() -> ProtobufType {
+        return ProtobufType.with {
             $0.inputTypes = inputTypes.map({ $0.asProtobuf() })
             $0.outputType = outputType.asProtobuf()
         }
     }
     
-    init(from proto: ProtoType) throws {
+    init(from proto: ProtobufType) throws {
         self.init(expects: try proto.inputTypes.map(Type.init),
                   returns: try Type(from: proto.outputType))
     }

--- a/Sources/Fuzzilli/FuzzIL/Variable.swift
+++ b/Sources/Fuzzilli/FuzzIL/Variable.swift
@@ -45,8 +45,6 @@ public struct Variable: Hashable, CustomStringConvertible {
     }
 }
 
-let maxNumberOfVariables = 0x10000
-
 extension Variable: Comparable {
     public static func <(lhs: Variable, rhs: Variable) -> Bool {
         return lhs.number < rhs.number

--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -283,7 +283,6 @@ public class Fuzzer {
     ///   - isCrash: Whether the program is a crashing sample in which case a crash event will be dispatched in any case.
     ///   - alwaysAddToCorpus: Whether the program should be added to the corpus regardless of whether it increases coverage.
     private func internalImportProgram(_ program: Program, enableDropout: Bool, isCrash: Bool, alwaysAddToCorpus: Bool = false, shouldMinimize: Bool) {
-        assert(program.check() == .valid)
         // Minimization is only possible for samples that have unique aspects
         assert(!alwaysAddToCorpus || !shouldMinimize)
 

--- a/Sources/Fuzzilli/Lifting/TypeCollectionAnalyzer.swift
+++ b/Sources/Fuzzilli/Lifting/TypeCollectionAnalyzer.swift
@@ -19,7 +19,7 @@ struct TypeCollectionAnalyzer {
     let specialProperties = ["__proto__"]
 
     func analyze(_ instr: Instruction) -> [Variable] {
-        switch instr.operation {
+        switch instr.op {
             case is LoadInteger, is LoadBigInt, is LoadFloat, is LoadBoolean, is LoadNull, is LoadUndefined,
                  is TypeOf, is InstanceOf, is In, is Dup, is Reassign, is Compare, is BeginForIn:
                 // No need to collect types for instructions interpreter can handle

--- a/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
+++ b/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
@@ -21,17 +21,17 @@ struct CallArgumentReducer: Reducer {
     }
     
     // TODO probably should remove as much as it can?
-    func reduce(_ program: Program, with verifier: ReductionVerifier) -> Program {
-        for instr in program {
-            switch instr.operation {
+    func reduce(_ code: inout Code, with verifier: ReductionVerifier) {
+        for instr in code {
+            switch instr.op {
             case let op as CallFunction:
                 guard op.numArguments > minArgCount else {
                     break
                 }
                 
                 let newOp = CallFunction(numArguments: op.numArguments - 1)
-                let newInstr = Instruction(operation: newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
-                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: program)
+                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
+                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
                 
             case let op as CallMethod:
                 guard op.numArguments > minArgCount else {
@@ -39,8 +39,8 @@ struct CallArgumentReducer: Reducer {
                 }
                 
                 let newOp = CallMethod(methodName: op.methodName, numArguments: op.numArguments - 1)
-                let newInstr = Instruction(operation: newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
-                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: program)
+                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
+                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
                 
             case let op as Construct:
                 guard op.numArguments > minArgCount else {
@@ -48,15 +48,13 @@ struct CallArgumentReducer: Reducer {
                 }
                 
                 let newOp = Construct(numArguments: op.numArguments - 1)
-                let newInstr = Instruction(operation: newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
-                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: program)
+                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
+                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
                 
             default:
                 break
             }
             
         }
-        
-        return program
     }
 }

--- a/Sources/Fuzzilli/Minimization/GenericInstructionReducer.swift
+++ b/Sources/Fuzzilli/Minimization/GenericInstructionReducer.swift
@@ -14,14 +14,13 @@
 
 /// Removes simple instructions from a program if they are not required.
 struct GenericInstructionReducer: Reducer {
-    func reduce(_ program: Program, with verifier: ReductionVerifier) -> Program {
-        for instr in program.reversed() {
-            if !instr.isSimple || instr.operation is Nop || instr.operation is Comment {
+    func reduce(_ code: inout Code, with verifier: ReductionVerifier) {
+        for instr in code.reversed() {
+            if !instr.isSimple || instr.op is Nop || instr.op is Comment {
                 continue
             }
             
-            verifier.tryNopping(instructionAt: instr.index, in: program)
+            verifier.tryNopping(instructionAt: instr.index, in: &code)
         }
-        return program
     }
 }

--- a/Sources/Fuzzilli/Minimization/ReplaceReducer.swift
+++ b/Sources/Fuzzilli/Minimization/ReplaceReducer.swift
@@ -14,18 +14,16 @@
 
 // Attemplts to replace code snippets with other, potentially shorter snippets.
 struct ReplaceReducer: Reducer {
-    func reduce(_ program: Program, with verifier: ReductionVerifier) -> Program {
-        for instr in program {
-            switch instr.operation {
+    func reduce(_ code: inout Code, with verifier: ReductionVerifier) {
+        for instr in code {
+            switch instr.op {
             case let op as Construct:
                 // Try replacing with a simple call
                 let newOp = CallFunction(numArguments: op.numArguments)
-                verifier.tryReplacing(instructionAt: instr.index, with: Instruction(operation: newOp, inouts: instr.inouts), in: program)
+                verifier.tryReplacing(instructionAt: instr.index, with: Instruction(newOp, inouts: instr.inouts), in: &code)
             default:
                 break
             }
         }
-        
-        return program
     }
 }

--- a/Sources/Fuzzilli/Modules/ThreadSync.swift
+++ b/Sources/Fuzzilli/Modules/ThreadSync.swift
@@ -35,29 +35,23 @@ public class LocalWorker: Module {
             
             // Corpus synchronization
             master.registerEventListener(for: master.events.InterestingProgramFound) { ev in
-                let program = ev.program.copy()
                 worker.async {
                     // Dropout can, if enabled in the fuzzer config, help workers become more independent
                     // from the rest of the fuzzers by forcing them to rediscover edges in different ways.
-                    worker.importProgram(program, enableDropout: true, shouldMinimize: false)
+                    worker.importProgram(ev.program, enableDropout: true, shouldMinimize: false)
                 }
             }
         }
         
-        // Access to classes appears to be thread-safe...
-        // TODO the programs should potentially be deep-copied, otherwise there will
-        // be Operation instances used by multiple threads.
         worker.registerEventListener(for: worker.events.CrashFound) { ev in
-            let program = ev.program.copy()
             master.async {
-                master.importCrash(program, shouldMinimize: false)
+                master.importCrash(ev.program, shouldMinimize: false)
             }
         }
         
         worker.registerEventListener(for: worker.events.InterestingProgramFound) { ev in
-            let program = ev.program.copy()
             master.async {
-                master.importProgram(program, shouldMinimize: false)
+                master.importProgram(ev.program, shouldMinimize: false)
             }
         }
         

--- a/Sources/Fuzzilli/Mutators/BaseInstructionMutator.swift
+++ b/Sources/Fuzzilli/Mutators/BaseInstructionMutator.swift
@@ -23,7 +23,7 @@ public class BaseInstructionMutator: Mutator {
         beginMutation(of: program)
         
         var candidates = [Int]()
-        for instr in program {
+        for instr in program.code {
             if canMutate(instr) {
                 candidates.append(instr.index)
             }
@@ -40,7 +40,7 @@ public class BaseInstructionMutator: Mutator {
         
         let b = fuzzer.makeBuilder()
         b.adopting(from: program) {
-            for instr in program {
+            for instr in program.code {
                 if toMutate.contains(instr.index) {
                     mutate(instr, b)
                 } else {
@@ -57,13 +57,13 @@ public class BaseInstructionMutator: Mutator {
     
     /// Overridden by child classes.
     /// Determines the set of instructions that can be mutated by this mutator
-    public func canMutate(_ instruction: Instruction) -> Bool {
+    public func canMutate(_ instr: Instruction) -> Bool {
         fatalError("This method must be overridden")
     }
     
     /// Overridden by child classes.
     /// Mutate a single statement
-    public func mutate(_ instruction: Instruction, _ builder: ProgramBuilder) {
+    public func mutate(_ instr: Instruction, _ builder: ProgramBuilder) {
         fatalError("This method must be overridden")
     }
 }

--- a/Sources/Fuzzilli/Mutators/InputMutator.swift
+++ b/Sources/Fuzzilli/Mutators/InputMutator.swift
@@ -29,6 +29,6 @@ public class InputMutator: BaseInstructionMutator {
         let selectedInput = Int.random(in: 0..<instr.numInputs)
         inouts[selectedInput] = b.randVar()
                 
-        b.append(Instruction(operation: instr.operation, inouts: inouts))
+        b.append(Instruction(instr.op, inouts: inouts))
     }
 }

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -25,7 +25,7 @@ public class OperationMutator: BaseInstructionMutator {
     public override func mutate(_ instr: Instruction, _ b: ProgramBuilder) {
         var newOp: Operation
         
-        switch instr.operation {
+        switch instr.op {
         case is LoadInteger:
             newOp = LoadInteger(value: b.genInt())
         case is LoadBigInt:
@@ -105,9 +105,9 @@ public class OperationMutator: BaseInstructionMutator {
                 newOp = BeginFor(comparator: op.comparator, op: chooseUniform(from: allBinaryOperators))
             }
         default:
-            fatalError("[OperationMutator] Unhandled Operation: \(type(of: instr.operation))")
+            fatalError("[OperationMutator] Unhandled Operation: \(type(of: instr.op))")
         }
 
-        b.adopt(Instruction(operation: newOp, inouts: instr.inouts), keepTypes: false)
+        b.adopt(Instruction(newOp, inouts: instr.inouts), keepTypes: false)
     }
 }

--- a/Sources/Fuzzilli/Util/Error.swift
+++ b/Sources/Fuzzilli/Util/Error.swift
@@ -21,4 +21,5 @@ enum FuzzilliError: Error {
     case programDecodingError(String)
     case corpusImportError(String)
     case evaluatorStateImportError(String)
+    case codeVerificationError(String)
 }

--- a/Tests/FuzzilliTests/InliningTest.swift
+++ b/Tests/FuzzilliTests/InliningTest.swift
@@ -37,11 +37,13 @@ class InliningTests: XCTestCase {
         let program = b.finalize()
 
         let reducer = InliningReducer()
-        let inlinedProgram = reducer.inline(f, in: program)
-        XCTAssert(inlinedProgram.check(checkForVariableHoles: false) == .valid)
-
-        // Inlining might leave holes in the variable space so the program must now be normalized.
-        inlinedProgram.normalize()
+        var inlinedCode = reducer.inline(f, in: program.code)
+        XCTAssert(inlinedCode.isStaticallyValid())
+        
+        // Inlining may insert some Nops to replace previous instructions. Remove those now.
+        inlinedCode.normalize()
+        
+        let inlinedProgram = Program(with: inlinedCode)
 
         let u: Variable
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -27,7 +27,6 @@ class LifterTests: XCTestCase {
             let code1 = fuzzer.lifter.lift(program)
             let code2 = fuzzer.lifter.lift(program)
             
-            // but of course preserves the instructions of the program.
             XCTAssertEqual(code1, code2)
         }
     }

--- a/Tests/FuzzilliTests/MutationsTest.swift
+++ b/Tests/FuzzilliTests/MutationsTest.swift
@@ -19,7 +19,7 @@ extension BaseInstructionMutator {
         beginMutation(of: program)
         let b = fuzzer.makeBuilder()
         b.adopting(from: program) {
-            for instr in program {
+            for instr in program.code {
                 if instr.index == index {
                     mutate(instr, b)
                 } else {

--- a/Tests/FuzzilliTests/ProgramBuilderTest.swift
+++ b/Tests/FuzzilliTests/ProgramBuilderTest.swift
@@ -27,8 +27,7 @@ class ProgramBuilderTests: XCTestCase {
             // Add to corpus since generate() does splicing as well
             fuzzer.corpus.add(program)
             
-            XCTAssert(program.count >= 100)
-            XCTAssert(program.check() == .valid)
+            XCTAssert(program.size >= 100)
         }
     }
     
@@ -54,7 +53,7 @@ class ProgramBuilderTests: XCTestCase {
         let expectedSplice = b.finalize()
         
         // Actual splice
-        b.splice(from: original, at: original.lastInstruction.index)
+        b.splice(from: original, at: original.code.lastInstruction.index)
         let actualSplice = b.finalize()
         
         XCTAssertEqual(expectedSplice, actualSplice)
@@ -87,8 +86,8 @@ class ProgramBuilderTests: XCTestCase {
         let expectedSplice = b.finalize()
         
         // Actual splice
-        let idx = original.lastInstruction.index - 1
-        XCTAssert(original[idx].operation is EndWhile)
+        let idx = original.code.lastInstruction.index - 1
+        XCTAssert(original.code[idx].op is EndWhile)
         b.splice(from: original, at: idx)
         let actualSplice = b.finalize()
         
@@ -134,8 +133,8 @@ class ProgramBuilderTests: XCTestCase {
         let expectedSplice = b.finalize()
         
         // Actual splice
-        let idx = original.lastInstruction.index - 1
-        XCTAssert(original[idx].operation is CallMethod)
+        let idx = original.code.lastInstruction.index - 1
+        XCTAssert(original.code[idx].op is CallMethod)
         b.splice(from: original, at: idx)
         let actualSplice = b.finalize()
 

--- a/Tests/FuzzilliTests/ProgramSerializationTest.swift
+++ b/Tests/FuzzilliTests/ProgramSerializationTest.swift
@@ -52,15 +52,16 @@ class ProgramSerializationTests: XCTestCase {
         
         let op = LoadInteger(value: 42)
         
-        b.append(Instruction(operation: op, output: b.nextVariable()))
-        b.append(Instruction(operation: op, output: b.nextVariable()))
-        b.append(Instruction(operation: op, output: b.nextVariable()))
+        b.append(Instruction(op, output: b.nextVariable()))
+        b.append(Instruction(op, output: b.nextVariable()))
+        b.append(Instruction(op, output: b.nextVariable()))
         
         let encodingCache = OperationCache.forEncoding()
         let decodingCache = OperationCache.forDecoding()
         
         let program = b.finalize()
-        XCTAssert(program[0].operation === program[1].operation && program[0].operation === program[2].operation)
+        XCTAssert(program.code[0].op === program.code[1].op &&
+                  program.code[0].op === program.code[2].op)
         
         var proto = program.asProtobuf(with: encodingCache)
         let data = try! proto.serializedData()
@@ -68,8 +69,9 @@ class ProgramSerializationTests: XCTestCase {
         let copy = try! Program(from: proto, with: decodingCache)
         
         XCTAssertEqual(program, copy)
-        XCTAssert(copy[0].operation !== program[0].operation)
-        XCTAssert(copy[0].operation === copy[1].operation && copy[0].operation === copy[2].operation)
+        XCTAssert(copy.code[0].op !== program.code[0].op)
+        XCTAssert(copy.code[0].op === copy.code[1].op &&
+                  copy.code[0].op === copy.code[2].op)
      }
     
     // As our equality operation is based on the protobuf representation, we do these tests here.


### PR DESCRIPTION
As programs are reference counted, it becomes much easier to reason about
them if they are immutable. Moreover, it is unclear how to deal with runtime
type information if a program is modified in place.

This commit introduces a new struct, Code, which is simply a list of
instructions that can be modified (if the struct itself is mutable). A
Program now contains an immutable code instance to hold its instructions.
The separation simplifies a few things as code that previously modified
programs (in particular the minimizers), can now simply operate on a Code
instance and recreate a new program from that once they are finished.