### PR TITLE
Cache program types

### DIFF
--- a/Sources/Fuzzilli/Core/Corpus.swift
+++ b/Sources/Fuzzilli/Core/Corpus.swift
@@ -122,17 +122,18 @@ public class Corpus: ComponentBase, Collection {
 
     /// Change type extensions for cached ones to save memory
     private func deduplicateTypeExtensions(in program: Program) {
-        var deduplicatedRuntimeTypes = ProgramTypes()
-        for (variable, instrMap) in program.runtimeTypes {
-            for typeData in instrMap {
-                deduplicatedRuntimeTypes.setType(
+        var deduplicatedTypes = ProgramTypes()
+        for (variable, instrTypes) in program.types {
+            for typeInfo in instrTypes {
+                deduplicatedTypes.setType(
                     of: variable,
-                    to: typeData.type.uniquify(with: &typeExtensionDeduplicationSet),
-                    at: typeData.index
+                    to: typeInfo.type.uniquify(with: &typeExtensionDeduplicationSet),
+                    at: typeInfo.index,
+                    quality: typeInfo.quality
                 )
             }
         }
-        program.runtimeTypes = deduplicatedRuntimeTypes
+        program.types = deduplicatedTypes
     }
     
     private func cleanup() {

--- a/Sources/Fuzzilli/FuzzIL/TypeCollectionStatus.swift
+++ b/Sources/Fuzzilli/FuzzIL/TypeCollectionStatus.swift
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-public enum TypeCollectionStatus: Equatable {
+public enum TypeCollectionStatus: UInt8 {
     case success
     case error
     case timeout
@@ -23,25 +23,6 @@ public enum TypeCollectionStatus: Equatable {
             case .failed: self = .error
             case .succeeded: self = .success
             case .timedOut: self = .timeout
-        }
-    }
-
-    public init(rawValue: Int) {
-        switch rawValue {
-            case 0: self = .success
-            case 1: self = .error
-            case 2: self = .timeout
-            case 3: self = .notAttempted
-            default: self = .notAttempted
-        }
-    }
-
-    public var rawValue: Int {
-        switch self {
-            case .success: return 0
-            case .error: return 1
-            case .timeout: return 2
-            case .notAttempted: return 3
         }
     }
 }

--- a/Sources/Fuzzilli/FuzzIL/TypeInfo.swift
+++ b/Sources/Fuzzilli/FuzzIL/TypeInfo.swift
@@ -1,0 +1,55 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+public enum TypeQuality: UInt8 {
+    case inferred
+    case runtime
+}
+
+// Store known types for program variables at specific instructions
+public struct TypeInfo: Equatable {
+    private let _index: UInt16
+    public let type: Type
+    public let quality: TypeQuality
+    public var index: Int {
+        return Int(_index)
+    }
+
+    public init(index: Int, type: Type, quality: TypeQuality) {
+        self._index = UInt16(index)
+        self.type = type
+        self.quality = quality
+    }
+
+    public static func == (lhs: TypeInfo, rhs: TypeInfo) -> Bool {
+        return lhs._index == rhs._index && lhs.type == rhs.type && lhs.quality == rhs.quality
+    }
+}
+
+extension TypeInfo: ProtobufConvertible {
+    public typealias ProtobufType = Fuzzilli_Protobuf_TypeInfo
+
+    func asProtobuf() -> ProtobufType {
+        return ProtobufType.with {
+            $0.index = UInt32(index)
+            $0.type = type.asProtobuf()
+            $0.quality = Fuzzilli_Protobuf_TypeQuality(rawValue: Int(quality.rawValue))!
+        }
+    }
+
+    public init(from proto: ProtobufType) throws {
+        self._index = UInt16(proto.index)
+        self.type = try Type(from: proto.type)
+        self.quality = TypeQuality(rawValue: UInt8(proto.quality.rawValue)) ?? .inferred
+    }
+}

--- a/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
+++ b/Sources/Fuzzilli/FuzzIL/TypeSystem.swift
@@ -910,6 +910,7 @@ extension Type: ProtobufConvertible {
             if let typeExtension = ext {
                 $0.properties = Array(typeExtension.properties)
                 $0.methods = Array(typeExtension.methods)
+
                 if let group = typeExtension.group {
                     $0.group = group
                 }

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -79,9 +79,6 @@ public class JavaScriptLifter: Lifter {
 
         let typeCollectionAnalyzer = TypeCollectionAnalyzer()
 
-        // Need an abstract interpreter if we are dumping type information.
-        var interpreter = AbstractInterpreter(for: self.environment)
-
         // Associates variables with the expressions that produce them
         var expressions = VariableMap<Expression>()
         func expr(for v: Variable) -> Expression {
@@ -128,12 +125,6 @@ public class JavaScriptLifter: Lifter {
                 let params = liftFunctionDefinitionParameters(op)
                 w.emit("\(keyword) \(instr.output)(\(params)) {")
                 w.increaseIndentionLevel()
-            }
-        
-            
-            // Interpret to compute type information if requested
-            if options.contains(.dumpTypes) {
-                interpreter.execute(instr)
             }
             
             var output: Expression? = nil
@@ -508,7 +499,7 @@ public class JavaScriptLifter: Lifter {
                 } else {
                     w.emit("\(decl(v)) = \(expression);")
                     if options.contains(.dumpTypes) {
-                        w.emitComment("\(v) = \(interpreter.type(of: v))")
+                        w.emitComment("\(v) = \(program.types.getType(of: v, at: instr.index))")
                     }
                 }
             }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-/// should be in sync with TypeCollectionStatus.swift
+/// Keep in sync with TypeCollectionStatus.swift
 public enum Fuzzilli_Protobuf_TypeCollectionStatus: SwiftProtobuf.Enum {
   public typealias RawValue = Int
   case success // = 0
@@ -78,6 +78,47 @@ extension Fuzzilli_Protobuf_TypeCollectionStatus: CaseIterable {
     .error,
     .timeout,
     .notattempted,
+  ]
+}
+
+#endif  // swift(>=4.2)
+
+/// Keep in sync with ProgramTypes.swift
+public enum Fuzzilli_Protobuf_TypeQuality: SwiftProtobuf.Enum {
+  public typealias RawValue = Int
+  case inferred // = 0
+  case runtime // = 1
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .inferred
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .inferred
+    case 1: self = .runtime
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .inferred: return 0
+    case .runtime: return 1
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Fuzzilli_Protobuf_TypeQuality: CaseIterable {
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static var allCases: [Fuzzilli_Protobuf_TypeQuality] = [
+    .inferred,
+    .runtime,
   ]
 }
 
@@ -951,12 +992,37 @@ public struct Fuzzilli_Protobuf_Instruction {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-public struct Fuzzilli_Protobuf_TypeMap {
+public struct Fuzzilli_Protobuf_TypeInfo {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var typeMap: Dictionary<UInt32,Fuzzilli_Protobuf_Type> = [:]
+  public var index: UInt32 = 0
+
+  public var type: Fuzzilli_Protobuf_Type {
+    get {return _type ?? Fuzzilli_Protobuf_Type()}
+    set {_type = newValue}
+  }
+  /// Returns true if `type` has been explicitly set.
+  public var hasType: Bool {return self._type != nil}
+  /// Clears the value of `type`. Subsequent reads from it will return its default value.
+  public mutating func clearType() {self._type = nil}
+
+  public var quality: Fuzzilli_Protobuf_TypeQuality = .inferred
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _type: Fuzzilli_Protobuf_Type? = nil
+}
+
+public struct Fuzzilli_Protobuf_InstrTypes {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var typeInfo: [Fuzzilli_Protobuf_TypeInfo] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -970,7 +1036,7 @@ public struct Fuzzilli_Protobuf_Program {
 
   public var instructions: [Fuzzilli_Protobuf_Instruction] = []
 
-  public var runtimeTypes: Dictionary<UInt32,Fuzzilli_Protobuf_TypeMap> = [:]
+  public var types: Dictionary<UInt32,Fuzzilli_Protobuf_InstrTypes> = [:]
 
   public var typeCollectionStatus: Fuzzilli_Protobuf_TypeCollectionStatus = .success
 
@@ -989,6 +1055,13 @@ extension Fuzzilli_Protobuf_TypeCollectionStatus: SwiftProtobuf._ProtoNameProvid
     1: .same(proto: "ERROR"),
     2: .same(proto: "TIMEOUT"),
     3: .same(proto: "NOTATTEMPTED"),
+  ]
+}
+
+extension Fuzzilli_Protobuf_TypeQuality: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "INFERRED"),
+    1: .same(proto: "RUNTIME"),
   ]
 }
 
@@ -1969,30 +2042,71 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Fuzzilli_Protobuf_TypeMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".TypeMap"
+extension Fuzzilli_Protobuf_TypeInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".TypeInfo"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "typeMap"),
+    1: .same(proto: "index"),
+    2: .same(proto: "type"),
+    3: .same(proto: "quality"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_Type>.self, value: &self.typeMap)
+      case 1: try decoder.decodeSingularUInt32Field(value: &self.index)
+      case 2: try decoder.decodeSingularMessageField(value: &self._type)
+      case 3: try decoder.decodeSingularEnumField(value: &self.quality)
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.typeMap.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_Type>.self, value: self.typeMap, fieldNumber: 1)
+    if self.index != 0 {
+      try visitor.visitSingularUInt32Field(value: self.index, fieldNumber: 1)
+    }
+    if let v = self._type {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if self.quality != .inferred {
+      try visitor.visitSingularEnumField(value: self.quality, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Fuzzilli_Protobuf_TypeMap, rhs: Fuzzilli_Protobuf_TypeMap) -> Bool {
-    if lhs.typeMap != rhs.typeMap {return false}
+  public static func ==(lhs: Fuzzilli_Protobuf_TypeInfo, rhs: Fuzzilli_Protobuf_TypeInfo) -> Bool {
+    if lhs.index != rhs.index {return false}
+    if lhs._type != rhs._type {return false}
+    if lhs.quality != rhs.quality {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_InstrTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".InstrTypes"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "typeInfo"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.typeInfo)
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.typeInfo.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.typeInfo, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_InstrTypes, rhs: Fuzzilli_Protobuf_InstrTypes) -> Bool {
+    if lhs.typeInfo != rhs.typeInfo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2002,7 +2116,7 @@ extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._Messa
   public static let protoMessageName: String = _protobuf_package + ".Program"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "instructions"),
-    2: .same(proto: "runtimeTypes"),
+    2: .same(proto: "types"),
     3: .same(proto: "typeCollectionStatus"),
   ]
 
@@ -2010,7 +2124,7 @@ extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._Messa
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
       case 1: try decoder.decodeRepeatedMessageField(value: &self.instructions)
-      case 2: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_TypeMap>.self, value: &self.runtimeTypes)
+      case 2: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_InstrTypes>.self, value: &self.types)
       case 3: try decoder.decodeSingularEnumField(value: &self.typeCollectionStatus)
       default: break
       }
@@ -2021,8 +2135,8 @@ extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._Messa
     if !self.instructions.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.instructions, fieldNumber: 1)
     }
-    if !self.runtimeTypes.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_TypeMap>.self, value: self.runtimeTypes, fieldNumber: 2)
+    if !self.types.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufUInt32,Fuzzilli_Protobuf_InstrTypes>.self, value: self.types, fieldNumber: 2)
     }
     if self.typeCollectionStatus != .success {
       try visitor.visitSingularEnumField(value: self.typeCollectionStatus, fieldNumber: 3)
@@ -2032,7 +2146,7 @@ extension Fuzzilli_Protobuf_Program: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
   public static func ==(lhs: Fuzzilli_Protobuf_Program, rhs: Fuzzilli_Protobuf_Program) -> Bool {
     if lhs.instructions != rhs.instructions {return false}
-    if lhs.runtimeTypes != rhs.runtimeTypes {return false}
+    if lhs.types != rhs.types {return false}
     if lhs.typeCollectionStatus != rhs.typeCollectionStatus {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -111,7 +111,7 @@ message Instruction {
     }
 }
 
-// should be in sync with TypeCollectionStatus.swift
+// Keep in sync with TypeCollectionStatus.swift
 enum TypeCollectionStatus {
     SUCCESS = 0;
     ERROR = 1;
@@ -119,12 +119,24 @@ enum TypeCollectionStatus {
     NOTATTEMPTED = 3;
 }
 
-message TypeMap {
-  map<uint32, Type> typeMap = 1;
+// Keep in sync with ProgramTypes.swift
+enum TypeQuality {
+    INFERRED = 0;
+    RUNTIME = 1;
+}
+
+message TypeInfo {
+    uint32 index = 1;
+    Type type = 2;
+    TypeQuality quality = 3;
+}
+
+message InstrTypes {
+  repeated TypeInfo typeInfo = 1;
 }
 
 message Program {
     repeated Instruction instructions = 1;
-    map<uint32, TypeMap> runtimeTypes = 2;
+    map<uint32, InstrTypes> types = 2;
     TypeCollectionStatus typeCollectionStatus = 3;
 }

--- a/Tests/FuzzilliTests/ProgramSerializationTest.swift
+++ b/Tests/FuzzilliTests/ProgramSerializationTest.swift
@@ -32,7 +32,6 @@ class ProgramSerializationTests: XCTestCase {
             
             let data1 = try! proto1.serializedData()
             let data2 = try! proto2.serializedData()
-            XCTAssertEqual(data1, data2)
             
             proto1 = try! Fuzzilli_Protobuf_Program(serializedData: data1)
             proto2 = try! Fuzzilli_Protobuf_Program(serializedData: data2)
@@ -46,7 +45,7 @@ class ProgramSerializationTests: XCTestCase {
     }
     
     func testProtobufSerializationWithOperationCache() {
-         let fuzzer = makeMockFuzzer()
+        let fuzzer = makeMockFuzzer()
         
         let b = fuzzer.makeBuilder()
         

--- a/Tests/FuzzilliTests/TestUtils.swift
+++ b/Tests/FuzzilliTests/TestUtils.swift
@@ -18,7 +18,10 @@ import Foundation
 extension Program: Equatable {
     // Fairly expensive equality testing, but it's only needed for testing anyway... :)
     public static func == (lhs: Program, rhs: Program) -> Bool {
-        return lhs.asProtobuf() == rhs.asProtobuf()
+        // We consider two programs to be equal if their code is equal
+        let code1 = lhs.code.map({ $0.asProtobuf() })
+        let code2 = rhs.code.map({ $0.asProtobuf() })
+        return code1 == code2
     }
 }
     


### PR DESCRIPTION
We should save infered types of program variables to avoid executing it by `AbstractInterpreter` more than once

* Attach all known types (not only runtime ones) to `Program` class
* Add `TypeQuality` to `ProgramTypes` struct
* `AbstractInterpreter` now returns type changes after execution
* Recollect static types after runtime types collection (using runtime types as hints)