### PR TITLE
When processing intereseting program, infer missing types when needed

### DIFF
--- a/Sources/Fuzzilli/Core/MutationEngine.swift
+++ b/Sources/Fuzzilli/Core/MutationEngine.swift
@@ -213,7 +213,7 @@ public class MutationEngine: ComponentBase, FuzzEngine {
 
         let prefixProgram = b.finalize()
 
-        fuzzer.collectRuntimeTypes(for: prefixProgram)
+        fuzzer.updateTypeInformation(for: prefixProgram)
         
         return prefixProgram
     }

--- a/Sources/Fuzzilli/FuzzIL/Program.swift
+++ b/Sources/Fuzzilli/FuzzIL/Program.swift
@@ -57,6 +57,10 @@ public final class Program {
     var isEmpty: Bool {
         return size == 0
     }
+
+    var hasTypeInformation: Bool {
+        return !types.isEmpty
+    }
 }
 
 extension Program: ProtobufConvertible {

--- a/Sources/Fuzzilli/FuzzIL/ProgramTypes.swift
+++ b/Sources/Fuzzilli/FuzzIL/ProgramTypes.swift
@@ -98,6 +98,10 @@ public struct ProgramTypes: Equatable, Sequence {
     public func makeIterator() -> VariableMap<[TypeInfo]>.Iterator {
         return types.makeIterator()
     }
+
+    public var isEmpty: Bool {
+        return types.isEmpty
+    }
 }
 
 extension ProgramTypes: ProtobufConvertible {


### PR DESCRIPTION
Now after minimization program lose its type info and we recollect it only if runtime types collection is enabled.

This PR changes it in a way, that we infer missing types everytime we have new runtime type hints or program does not have any types