### PR TITLE
Add type API in program

### DIFF
--- a/Sources/Fuzzilli/Core/Corpus.swift
+++ b/Sources/Fuzzilli/Core/Corpus.swift
@@ -128,7 +128,7 @@ public class Corpus: ComponentBase, Collection {
                 deduplicatedTypes.setType(
                     of: variable,
                     to: typeInfo.type.uniquify(with: &typeExtensionDeduplicationSet),
-                    at: typeInfo.index,
+                    after: typeInfo.index,
                     quality: typeInfo.quality
                 )
             }

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -271,7 +271,7 @@ public class ProgramBuilder {
     
     /// Type information access.
     public func type(of v: Variable) -> Type {
-        return types.getType(of: v, at: code.lastInstruction.index) 
+        return types.getType(of: v, after: code.lastInstruction.index)
     }
     
     public func methodSignature(of methodName: String, on object: Variable) -> FunctionSignature {
@@ -382,7 +382,7 @@ public class ProgramBuilder {
                 interpreter?.setType(of: adoptedVariable, to: type)
                 // We should save this type even if we do not have interpreter
                 // This way we can use runtime types without interpreter
-                types.setType(of: adoptedVariable, to: type, at: code.lastInstruction.index, quality: .runtime)
+                types.setType(of: adoptedVariable, to: type, after: code.lastInstruction.index, quality: .runtime)
             }
         }
     }
@@ -450,7 +450,7 @@ public class ProgramBuilder {
             for (idx, input) in instr.inputs.enumerated() {
                 neededInputs.append(input)
                 if probability(0.2) && mode != .conservative {
-                    var type = program.types.getType(of: input, at: instr.index)
+                    var type = program.type(of: input, before: instr.index)
                     if type == .unknown {
                         type = .anything
                     }
@@ -990,7 +990,7 @@ public class ProgramBuilder {
         // Update type information
         let typeChanges = interpreter?.execute(instr) ?? []
         for (variable, type) in typeChanges {
-            types.setType(of: variable, to: type, at: code.lastInstruction.index, quality: .inferred)
+            types.setType(of: variable, to: type, after: code.lastInstruction.index, quality: .inferred)
         }
 
         // Update our analyses

--- a/Sources/Fuzzilli/FuzzIL/Program.swift
+++ b/Sources/Fuzzilli/FuzzIL/Program.swift
@@ -48,6 +48,14 @@ public final class Program {
         self.types = types
     }
 
+    public func type(of variable: Variable, after instrIndex: Int) -> Type {
+        return types.getType(of: variable, after: instrIndex)
+    }
+
+    public func type(of variable: Variable, before instrIndex: Int) -> Type {
+        return types.getType(of: variable, after: instrIndex - 1)
+    }
+
     /// The number of instructions in this program.
     var size: Int {
         return code.count

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -499,7 +499,7 @@ public class JavaScriptLifter: Lifter {
                 } else {
                     w.emit("\(decl(v)) = \(expression);")
                     if options.contains(.dumpTypes) {
-                        w.emitComment("\(v) = \(program.types.getType(of: v, at: instr.index))")
+                        w.emitComment("\(v) = \(program.type(of: v, after: instr.index))")
                     }
                 }
             }

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -157,6 +157,19 @@ if args.unusedOptionals.count > 0 {
     exit(-1)
 }
 
+// Forbid this option as runtime types collection relies on abstractInterpreter
+if disableAbstractInterpreter, collectRuntimeTypes {
+    print(
+        """
+        It is not possible to disable abstract interpretation and enable runtime types collection at the same time.
+        Remove at least one of the arguments:
+        --noAbstractInterpretation
+        --collectRuntimeTypes
+        """
+    )
+    exit(-1)
+}
+
 //
 // Construct a fuzzer instance.
 //


### PR DESCRIPTION
* Rename `at` instruction to `after` instruction
* Add getType to `Program` class
* Forbid runtime types collection mode without abstractInterpreter
* Enforce failure on querying type of variable before definition