### PR TITLE
AbstractInterpreter - save only state diffs

### DIFF
--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -6,12 +6,14 @@ extension AbstractInterpreterTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__AbstractInterpreterTests = [
-        ("testArryCreation", testArryCreation),
+        ("testArrayCreation", testArrayCreation),
         ("testBasicTypeTracking", testBasicTypeTracking),
         ("testBuiltinTypeInference", testBuiltinTypeInference),
         ("testConstructorTypeInference", testConstructorTypeInference),
         ("testFunctionTypes", testFunctionTypes),
         ("testIfElseHandling", testIfElseHandling),
+        ("testDeeplyNestedBlocksHandling", testDeeplyNestedBlocksHandling),
+        ("testFunctionReassignment", testFunctionReassignment),
         ("testLoopAndFunctionHandling", testLoopAndFunctionHandling),
         ("testMethodTypeInference", testMethodTypeInference),
         ("testObjectTypeTracking", testObjectTypeTracking),


### PR DESCRIPTION
Currently AbstractInterpreter copies all types when creating new internal state, which is quite inefficient.
This PR tries to remember only diffs of states (i.e. types that changed) + current state.

* stateChangesStack - each entry remembers list of sibling states - each of them remembers last known type in that block

* currentState - all current variable types for fast type queries