### PR TITLE
Implements variable deletion

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -394,6 +394,10 @@ public let CodeGenerators: [CodeGenerator] = [
         b.throwException(v)
     },
 
+    CodeGenerator("DeleteVarGenerator", input: .anything) { b, v in
+        b.deleteVar(v)
+    },
+
     //
     // Language-specific Generators
     //

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1137,6 +1137,10 @@ public class ProgramBuilder {
         perform(ThrowException(), withInputs: [value])
     }
 
+    public func deleteVar(_ input: Variable) {
+        perform(DeleteVar(), withInputs: [input])
+    }
+
     public func codeString(_ body: () -> Variable) -> Variable {
         let instr = perform(BeginCodeString())
         let returnValue = body()

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -434,6 +434,8 @@ extension Instruction: ProtobufConvertible {
                 $0.beginBlockStatement = Fuzzilli_Protobuf_BeginBlockStatement()
             case is EndBlockStatement:
                 $0.endBlockStatement = Fuzzilli_Protobuf_EndBlockStatement()
+            case is DeleteVar:
+                $0.deleteVar = Fuzzilli_Protobuf_DeleteVar()
             default:
                 fatalError("Unhandled operation type in protobuf conversion: \(op)")
             }
@@ -634,6 +636,8 @@ extension Instruction: ProtobufConvertible {
             op = EndBlockStatement()
         case .nop(_):
             op = Nop()
+        case .deleteVar(_):
+            op = DeleteVar()
         }
         
         guard op.numInputs + op.numOutputs + op.numInnerOutputs == inouts.count else {

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -774,6 +774,12 @@ class EndBlockStatement: Operation {
     }
 }
 
+class DeleteVar: Operation {
+    init() {
+        super.init(numInputs: 1, numOutputs: 0)
+    }
+}
+
 /// Internal operations.
 ///
 /// These can be used for internal fuzzer operations but will not appear in the corpus.

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -310,6 +310,9 @@ public class FuzzILLifter: Lifter {
                 w.decreaseIndentionLevel()
                 w.emit("EndBlockStatement")
 
+            case is DeleteVar:
+                w.emit("Delete \(input(0))")
+
             case is Print:
                 w.emit("Print \(input(0))")
 

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -492,6 +492,9 @@ public class JavaScriptLifter: Lifter {
             case is Print:
                 w.emit("fuzzilli('FUZZILLI_PRINT', \(input(0)));")
 
+            case is DeleteVar:
+                w.emit("delete \(input(0));")
+
             default:
                 fatalError("Unhandled Operation: \(type(of: instr.op))")
             }

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -106,6 +106,8 @@ public class OperationMutator: BaseInstructionMutator {
             } else {
                 newOp = BeginFor(comparator: op.comparator, op: chooseUniform(from: allBinaryOperators))
             }
+        case is DeleteVar:
+            newOp = DeleteVar()
         default:
             fatalError("Unhandled Operation: \(type(of: instr.op))")
         }

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -1195,6 +1195,16 @@ public struct Fuzzilli_Protobuf_Nop {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_DeleteVar {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "fuzzilli.protobuf"
@@ -3130,6 +3140,25 @@ extension Fuzzilli_Protobuf_Nop: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_Nop, rhs: Fuzzilli_Protobuf_Nop) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_DeleteVar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DeleteVar"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_DeleteVar, rhs: Fuzzilli_Protobuf_DeleteVar) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -334,3 +334,6 @@ message EndBlockStatement {
 
 message Nop {
 }
+
+message DeleteVar {
+}

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -799,6 +799,14 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {_uniqueStorage()._operation = .nop(newValue)}
   }
 
+  public var deleteVar: Fuzzilli_Protobuf_DeleteVar {
+    get {
+      if case .deleteVar(let v)? = _storage._operation {return v}
+      return Fuzzilli_Protobuf_DeleteVar()
+    }
+    set {_uniqueStorage()._operation = .deleteVar(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Operation: Equatable {
@@ -885,6 +893,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case beginBlockStatement(Fuzzilli_Protobuf_BeginBlockStatement)
     case endBlockStatement(Fuzzilli_Protobuf_EndBlockStatement)
     case nop(Fuzzilli_Protobuf_Nop)
+    case deleteVar(Fuzzilli_Protobuf_DeleteVar)
 
   #if !swift(>=4.1)
     public static func ==(lhs: Fuzzilli_Protobuf_Instruction.OneOf_Operation, rhs: Fuzzilli_Protobuf_Instruction.OneOf_Operation) -> Bool {
@@ -971,6 +980,7 @@ public struct Fuzzilli_Protobuf_Instruction {
       case (.beginBlockStatement(let l), .beginBlockStatement(let r)): return l == r
       case (.endBlockStatement(let l), .endBlockStatement(let r)): return l == r
       case (.nop(let l), .nop(let r)): return l == r
+      case (.deleteVar(let l), .deleteVar(let r)): return l == r
       default: return false
       }
     }
@@ -1169,6 +1179,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     83: .same(proto: "beginBlockStatement"),
     84: .same(proto: "endBlockStatement"),
     64: .same(proto: "nop"),
+    87: .same(proto: "deleteVar"),
   ]
 
   fileprivate class _StorageClass {
@@ -1851,6 +1862,14 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           }
           try decoder.decodeSingularMessageField(value: &v)
           if let v = v {_storage._operation = .endAsyncGeneratorFunctionDefinition(v)}
+        case 87:
+          var v: Fuzzilli_Protobuf_DeleteVar?
+          if let current = _storage._operation {
+            try decoder.handleConflictingOneOf()
+            if case .deleteVar(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {_storage._operation = .deleteVar(v)}
         default: break
         }
       }
@@ -2027,6 +2046,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try visitor.visitSingularMessageField(value: v, fieldNumber: 85)
       case .endAsyncGeneratorFunctionDefinition(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 86)
+      case .deleteVar(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 87)
       case nil: break
       }
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -107,6 +107,7 @@ message Instruction {
         BeginBlockStatement beginBlockStatement = 83;
         EndBlockStatement endBlockStatement = 84;
         Nop nop = 64;
+        DeleteVar deleteVar = 87;
     }
 }
 

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -75,6 +75,7 @@ let codeGeneratorWeights = [
     "TryCatchGenerator":                    5,
     "ThrowGenerator":                       1,
     "BlockStatementGenerator":              1,
+    "DeleteVarGenerator":                   5,
     
     // Special generators
     "WellKnownPropertyLoadGenerator":       5,


### PR DESCRIPTION
Closes issue #163 

Two questions:
- What's the proper type in CodeGenerators.swift? .anything seems too loose and .object overly restrictive
- I added the required functions at the bottom of the relevant sections across the various files. Is there an order I should be following?

The weight assigned to DeleteVarGenerator in codeGeneratorWeights.swift was chosen to be the same as the similar functions PropertyRemovalGenerator, ElementRemovalGenerator, and ComputedPropertyRemovalGenerator