### PR TITLE
Backwards compatibility for Swift <v5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .target(name: "libreprl", dependencies: []),
         .target(name: "libcoverage", dependencies: [], linkerSettings: [.linkedLibrary("rt", .when(platforms: [.linux]))]),
         .target(name: "Fuzzilli", dependencies: ["SwiftProtobuf", "libsocket", "libreprl", "libcoverage", "JS"]),
-        //.target(name: "REPRLRun", dependencies: ["libreprl"]),
+        .target(name: "REPRLRun", dependencies: ["libreprl"]),
         .target(name: "FuzzilliCli", dependencies: ["Fuzzilli"]),
         .target(name: "JS", dependencies: []),
         .target(name: "Benchmarks", dependencies: ["Fuzzilli"]),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .target(name: "libreprl", dependencies: []),
         .target(name: "libcoverage", dependencies: [], linkerSettings: [.linkedLibrary("rt", .when(platforms: [.linux]))]),
         .target(name: "Fuzzilli", dependencies: ["SwiftProtobuf", "libsocket", "libreprl", "libcoverage", "JS"]),
-        .target(name: "REPRLRun", dependencies: ["libreprl"]),
+        //.target(name: "REPRLRun", dependencies: ["libreprl"]),
         .target(name: "FuzzilliCli", dependencies: ["Fuzzilli"]),
         .target(name: "JS", dependencies: []),
         .target(name: "Benchmarks", dependencies: ["Fuzzilli"]),

--- a/Sources/FuzzILTool/main.swift
+++ b/Sources/FuzzILTool/main.swift
@@ -38,7 +38,7 @@ func loadProgram(from path: String) throws -> Program {
 func loadAllPrograms(in dirPath: String) -> [(filename: String, program: Program)] {
     var isDir: ObjCBool = false
     if !FileManager.default.fileExists(atPath: dirPath, isDirectory:&isDir) || !isDir.boolValue {
-        print("\(path) is not a directory!")
+        print("\(dirPath) is not a directory!")
         exit(-1)
     }
 

--- a/Sources/Fuzzilli/Core/Corpus.swift
+++ b/Sources/Fuzzilli/Core/Corpus.swift
@@ -167,15 +167,15 @@ public class Corpus: ComponentBase, Collection {
     }
 
     public var startIndex: Int {
-        programs.startIndex
+        return programs.startIndex
     }
 
     public var endIndex: Int {
-        programs.endIndex
+        return programs.endIndex
     }
 
     public subscript(index: Int) -> Program {
-        programs[index]
+        return programs[index]
     }
 
     public func index(after i: Int) -> Int {

--- a/Sources/Fuzzilli/FuzzIL/Code.swift
+++ b/Sources/Fuzzilli/FuzzIL/Code.swift
@@ -52,10 +52,10 @@ public struct Code: Collection {
     /// Access the ith instruction in this code.
     public subscript(i: Int) -> Instruction {
         get {
-            instructions[i]
+            return instructions[i]
         }
         set {
-            instructions[i] = Instruction(newValue.op, inouts: newValue.inouts, index: i)
+            return instructions[i] = Instruction(newValue.op, inouts: newValue.inouts, index: i)
         }
     }
     

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -262,7 +262,7 @@ extension Instruction: ProtobufConvertible {
 
     func asProtobuf(with opCache: OperationCache?) -> ProtobufType {
         func convertEnum<S: Equatable, P: RawRepresentable>(_ s: S, _ allValues: [S]) -> P where P.RawValue == Int {
-            P(rawValue: allValues.firstIndex(of: s)!)!
+            return P(rawValue: allValues.firstIndex(of: s)!)!
         }
         
         let result = ProtobufType.with {

--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -418,8 +418,19 @@ public class Fuzzer {
         let execution = runner.run(script, withTimeout: 30 * config.timeout)
         // JS prints lines alternating between variable name and its type
         let fuzzout = execution.fuzzout
+        
+        // Split String based on newline deliminator
+#if swift(>=5.1)
+        // https://github.com/apple/swift-evolution/blob/master/proposals/0221-character-properties.md
         let lines = fuzzout.split(whereSeparator: \.isNewline)
-
+#else        
+        // Swift v3+ compatible split
+        var lines: [String] = []
+        fuzzout.enumerateLines { line, _ in
+                lines.append(line)
+        }
+#endif 
+       
         if execution.outcome == .succeeded {
             do {
                 var lineNumber = 0

--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -420,15 +420,15 @@ public class Fuzzer {
         let fuzzout = execution.fuzzout
         
         // Split String based on newline deliminator
-#if swift(>=5.1)
-        // https://github.com/apple/swift-evolution/blob/master/proposals/0221-character-properties.md
-        let lines = fuzzout.split(whereSeparator: \.isNewline)
-#else        
+#if swift(<5.2)
         // Swift v3+ compatible split
         var lines: [String] = []
         fuzzout.enumerateLines { line, _ in
                 lines.append(line)
         }
+#elseif swift(>=5.2) 
+        // https://github.com/apple/swift-evolution/blob/master/proposals/0221-character-properties.md
+        let lines = fuzzout.split(whereSeparator: \.isNewline)
 #endif 
        
         if execution.outcome == .succeeded {

--- a/Sources/Fuzzilli/Lifting/ScriptWriter.swift
+++ b/Sources/Fuzzilli/Lifting/ScriptWriter.swift
@@ -42,7 +42,7 @@ struct ScriptWriter {
         }
 
         func canRemoveWhitespaces(_ c: Character) -> Bool {
-            !c.isLetter && !c.isNumber && !ScriptWriter.specialCharacters.contains(c)
+            return !c.isLetter && !c.isNumber && !ScriptWriter.specialCharacters.contains(c)
         }
 
         for c in line {

--- a/Sources/REPRLRun/main.swift
+++ b/Sources/REPRLRun/main.swift
@@ -57,8 +57,10 @@ if execute("").status != 0 {
     exit(1)
 }
 
+#if swift(>=5.2)
 // Run a couple of tests now
 runREPRLTests()
+#endif
 
 print("Enter code to run, then hit enter to execute it")
 while true {

--- a/Sources/REPRLRun/main.swift
+++ b/Sources/REPRLRun/main.swift
@@ -51,38 +51,6 @@ func execute(_ code: String) -> (status: Int32, exec_time: UInt64) {
     return (status, exec_time)
 }
 
-// Check whether REPRL works at all
-if execute("").status != 0 {
-    print("Script execution failed, REPRL support does not appear to be working")
-    exit(1)
-}
-
-#if swift(>=5.2)
-// Run a couple of tests now
-runREPRLTests()
-#endif
-
-print("Enter code to run, then hit enter to execute it")
-while true {
-    print("> ", terminator: "")
-    guard let code = readLine(strippingNewline: false) else {
-        print("Bye")
-        break
-    }
-    
-    let (status, exec_time) = execute(code)
-    
-    if status < 0 {
-        print("Error during script execution: \(String(cString: reprl_get_last_error(ctx))). REPRL support in the target probably isn't working correctly...")
-        continue
-    }
-    
-    print("Execution finished with status \(status) (signaled: \(RIFSIGNALED(status) != 0), timed out: \(RIFTIMEDOUT(status) != 0)) and took \(exec_time / 1000)ms")
-    print("========== Fuzzout ==========\n\(String(cString: reprl_fetch_fuzzout(ctx)))")
-    print("========== Stdout ==========\n\(String(cString: reprl_fetch_stdout(ctx)))")
-    print("========== Stderr ==========\n\(String(cString: reprl_fetch_stderr(ctx)))")
-}
-
 func runREPRLTests() {
     print("Running REPRL tests...")
     var numFailures = 0
@@ -123,4 +91,34 @@ func runREPRLTests() {
     } else {
         print("Not all tests passed. That means REPRL support likely isn't properly implemented in the target engine")
     }
+}
+
+// Check whether REPRL works at all
+if execute("").status != 0 {
+    print("Script execution failed, REPRL support does not appear to be working")
+    exit(1)
+}
+
+// Run a couple of tests now
+runREPRLTests()
+
+print("Enter code to run, then hit enter to execute it")
+while true {
+    print("> ", terminator: "")
+    guard let code = readLine(strippingNewline: false) else {
+        print("Bye")
+        break
+    }
+    
+    let (status, exec_time) = execute(code)
+    
+    if status < 0 {
+        print("Error during script execution: \(String(cString: reprl_get_last_error(ctx))). REPRL support in the target probably isn't working correctly...")
+        continue
+    }
+    
+    print("Execution finished with status \(status) (signaled: \(RIFSIGNALED(status) != 0), timed out: \(RIFTIMEDOUT(status) != 0)) and took \(exec_time / 1000)ms")
+    print("========== Fuzzout ==========\n\(String(cString: reprl_fetch_fuzzout(ctx)))")
+    print("========== Stdout ==========\n\(String(cString: reprl_fetch_stdout(ctx)))")
+    print("========== Stderr ==========\n\(String(cString: reprl_fetch_stderr(ctx)))")
 }


### PR DESCRIPTION
After investigating #185 I was able to root-cause the error - Swift <v5.2 is not compatible, as is, for the following reasons:

1. Implicit returns just don't work in <v5.2 (no idea why)
1. `runREPRLTests` requires preprocesser flags to disable run
1. `dirPath` typo in FuzzILTool (unrelated bug)

So explicit `return`'s added in, and preprocesser flag set based on `>=5.2`, i.e.,
```swift
#if swift(>=5.2)
// Run a couple of tests now
runREPRLTests()
#endif
```

Testing Dockerfile (will fail to build, as is):
```dockerfile
FROM swift:5.0
# swift v5.0 breaks on current master branch of googleprojectzero/fuzzilli
#ENV FUZZILLI "--branch swift-v5.0 https://github.com/drtychai/fuzzilli"

#FROM swift:5.2
ENV FUZZILLI "https://github.com/googleprojectzero/fuzzilli"

ENV F_DIR /fuzzilli

RUN apt update && apt upgrade -y && apt install -y git 
RUN git clone --depth 1 ${FUZZILLI} ${F_DIR}

WORKDIR ${F_DIR}
RUN swift build
```