### PR TITLE
Moves core file creation check before moving corpus directories

### DIFF
--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -589,10 +589,8 @@ public class Fuzzer {
         return b.finalize()
     }
 
-    /// Runs a number of startup tests to check whether everything is configured correctly.
-    public func runStartupTests() {
-        assert(isInitialized)
-
+    // Verifies that the fuzzer is not creating a large number of core dumps
+    public func checkCoreFileGeneration() {
         #if os(Linux)
         do {
             let corePattern = try String(contentsOfFile: "/proc/sys/kernel/core_pattern", encoding: String.Encoding.ascii)
@@ -603,6 +601,11 @@ public class Fuzzer {
             logger.warning("Could not check core dump behaviour. Please ensure core_pattern is set to '|/bin/false'")
         }
         #endif
+    }
+
+    /// Runs a number of startup tests to check whether everything is configured correctly.
+    public func runStartupTests() {
+        assert(isInitialized)
 
         // Check if we can execute programs
         var execution = execute(Program())

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -340,6 +340,9 @@ fuzzer.sync {
     // Always want some statistics.
     fuzzer.addModule(Statistics())
 
+    // Check core file generation on linux, prior to moving corpus file directories
+    fuzzer.checkCoreFileGeneration()
+
     // Store samples to disk if requested.
     if let path = storagePath {
         if resume {


### PR DESCRIPTION
Previously, the fuzzer will move the corpus directory to `old_corpus` in preparation to resume a session, and then exit due to `kernel.core_pattern` not being set properly. This forces the user to have to move the files back in order to properly resume the session, which is not intuitive, and results in data loss if not done prior to restarting the fuzzer.

This moves the `kernel.core_pattern` check before moving the directory.