### PR TITLE
support generation of array with holes

### DIFF
--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -187,7 +187,8 @@ public class JavaScriptLifter: Lifter {
                 output = ObjectLiteral.new("{" + properties.joined(separator: ",") + "}")
 
             case is CreateArray:
-                let elems = instr.inputs.map({ expr(for: $0).text == "undefined" ? "" : expr(for: $0).text }).joined(separator: ",")
+                // When creating arrays, treat undefined elements as holes. This also relies on literals always being inlined.
+                let elems = instr.inputs.map({ let text = expr(for: $0).text; return text == "undefined" ? "" : text }).joined(separator: ",")
                 output = ArrayLiteral.new("[" + elems + "]")
 
             case let op as CreateObjectWithSpread:

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -187,7 +187,7 @@ public class JavaScriptLifter: Lifter {
                 output = ObjectLiteral.new("{" + properties.joined(separator: ",") + "}")
 
             case is CreateArray:
-                let elems = instr.inputs.map({ expr(for: $0).text }).joined(separator: ",")
+                let elems = instr.inputs.map({ expr(for: $0).text == "undefined" ? "" : expr(for: $0).text }).joined(separator: ",")
                 output = ArrayLiteral.new("[" + elems + "]")
 
             case let op as CreateObjectWithSpread:

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -363,6 +363,31 @@ class LifterTests: XCTestCase {
 
         XCTAssertEqual(lifted_program,expected_program)
     }
+
+    func testHoleyArrayLifting(){
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        var initialValues = [Variable]()
+        initialValues.append(b.loadInt(1))
+        initialValues.append(b.loadInt(2))
+        initialValues.append(b.loadUndefined())
+        initialValues.append(b.loadInt(4))
+        initialValues.append(b.loadUndefined())
+        initialValues.append(b.loadInt(5))
+        b.createArray(with: initialValues)
+
+        let program = b.finalize()
+
+        let lifted_program = fuzzer.lifter.lift(program)
+
+        let expected_program = """
+        const v4 = [1,2,,4,,5];
+
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
 }
 
 extension LifterTests {
@@ -376,6 +401,7 @@ extension LifterTests {
             ("testDoWhileLifting", testDoWhileLifting),
             ("testBlockStatements", testBlockStatements),
             ("testAsyncGeneratorLifting", testAsyncGeneratorLifting),
+            ("testHoleyArray", testHoleyArrayLifting),
         ]
     }
 }

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -374,7 +374,10 @@ class LifterTests: XCTestCase {
         initialValues.append(b.loadUndefined())
         initialValues.append(b.loadInt(4))
         initialValues.append(b.loadUndefined())
-        initialValues.append(b.loadInt(5))
+        initialValues.append(b.loadInt(6))
+        let v = b.loadString("foobar")
+        b.reassign(v, to: b.loadUndefined())
+        initialValues.append(v)
         b.createArray(with: initialValues)
 
         let program = b.finalize()
@@ -382,7 +385,9 @@ class LifterTests: XCTestCase {
         let lifted_program = fuzzer.lifter.lift(program)
 
         let expected_program = """
-        const v6 = [1,2,,4,,5];
+        let v6 = "foobar";
+        v6 = undefined;
+        const v8 = [1,2,,4,,6,v6];
 
         """
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -382,7 +382,7 @@ class LifterTests: XCTestCase {
         let lifted_program = fuzzer.lifter.lift(program)
 
         let expected_program = """
-        const v4 = [1,2,,4,,5];
+        const v6 = [1,2,,4,,5];
 
         """
 

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -59,6 +59,7 @@ extension LifterTests {
         ("testFuzzILLifter", testFuzzILLifter),
         ("testLiftingOptions", testLiftingOptions),
         ("testNestedCodeStrings", testNestedCodeStrings),
+        ("testHoleyArray", testHoleyArrayLifting),
     ]
 }
 


### PR DESCRIPTION
The JavaScriptLifter is unable to generate arrays with holes since it lifts the *loadUndefined* operation to the string *undefined*. As a result, this replaces holes in an array with JS *undefined*. Semantically, this should not be a problem since holes in an array are considered as undefined values and testing array[index_at_hole] === undefined would return true.

However, I've come across this [JSC testcase](https://github.com/WebKit/WebKit/blob/main/JSTests/stress/array-indexof-array-prototype-change.js) that demonstrates how arrays initialised with holes are affected by JIT optimisations. In this testcase, if the hole in the initialisation were to be replaced with *undefined*, it would case the testcase to  fail (presumably due to the JIT optimising array access to the hole differently).

I did consider creating a new operation (e.g. *loadHole*) for the purpose of adding holes to an array but that seemed redundant  when a minor change to the JSLifter would achieve the same effect.