### PR TITLE
Add CallComputedMethod operation

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -254,8 +254,9 @@ public let CodeGenerators: [CodeGenerator] = [
             guard b.mode != .conservative else { return }
             methodName = b.genMethodName()
         }
+        let method = b.loadString(methodName!)
         guard let arguments = b.randCallArguments(forMethod: methodName!, on: obj) else { return }
-        b.callMethod(methodName!, on: obj, withArgs: arguments)
+        b.callComputedMethod(method, on: obj, withArgs: arguments)
     },
 
     CodeGenerator("FunctionCallGenerator", input: .function()) { b, f in

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -248,6 +248,16 @@ public let CodeGenerators: [CodeGenerator] = [
         b.callMethod(methodName!, on: obj, withArgs: arguments)
     },
 
+    CodeGenerator("ComputedMethodCallGenerator", input: .object()) { b, obj in
+        var methodName = b.type(of: obj).randomMethod()
+        if methodName == nil {
+            guard b.mode != .conservative else { return }
+            methodName = b.genMethodName()
+        }
+        guard let arguments = b.randCallArguments(forMethod: methodName!, on: obj) else { return }
+        b.callMethod(methodName!, on: obj, withArgs: arguments)
+    },
+
     CodeGenerator("FunctionCallGenerator", input: .function()) { b, f in
         guard let arguments = b.randCallArguments(for: f) else { return }
         b.callFunction(f, withArgs: arguments)

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1062,6 +1062,11 @@ public class ProgramBuilder {
     }
 
     @discardableResult
+    public func callComputedMethod(_ name: String, on object: Variable, withArgs arguments: [Variable]) -> Variable {
+        return perform(CallComputedMethod(methodName: name, numArguments: arguments.count), withInputs: [object] + arguments).output
+    }
+
+    @discardableResult
     public func callFunction(_ function: Variable, withArgs arguments: [Variable]) -> Variable {
         return perform(CallFunction(numArguments: arguments.count), withInputs: [function] + arguments).output
     }

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1062,8 +1062,8 @@ public class ProgramBuilder {
     }
 
     @discardableResult
-    public func callComputedMethod(_ name: String, on object: Variable, withArgs arguments: [Variable]) -> Variable {
-        return perform(CallComputedMethod(methodName: name, numArguments: arguments.count), withInputs: [object] + arguments).output
+    public func callComputedMethod(_ name: Variable, on object: Variable, withArgs arguments: [Variable]) -> Variable {
+        return perform(CallComputedMethod(numArguments: arguments.count), withInputs: [object, name] + arguments).output
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -351,8 +351,8 @@ public struct AbstractInterpreter {
         case let op as CallMethod:
             set(instr.output, inferMethodSignature(of: op.methodName, on: instr.input(0)).outputType)
 
-        case let op as CallComputedMethod:
-            set(instr.output, inferMethodSignature(of: op.methodName, on: instr.input(0)).outputType)
+        case is CallComputedMethod:
+            set(instr.output, inferMethodSignature(of: instr.input(1).description, on: instr.input(0)).outputType)
 
         case is Construct:
             set(instr.output, inferConstructedType(of: instr.input(0)))

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -351,6 +351,9 @@ public struct AbstractInterpreter {
         case let op as CallMethod:
             set(instr.output, inferMethodSignature(of: op.methodName, on: instr.input(0)).outputType)
 
+        case let op as CallComputedMethod:
+            set(instr.output, inferMethodSignature(of: op.methodName, on: instr.input(0)).outputType)
+
         case is Construct:
             set(instr.output, inferConstructedType(of: instr.input(0)))
 

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -340,8 +340,11 @@ public struct AbstractInterpreter {
         case let op as LoadProperty:
             set(instr.output, inferPropertyType(of: op.propertyName, on: instr.input(0)))
 
+        // TODO: An additional analyzer is required to determine the runtime value of the output variable generated from the following operations
+        // For now we treat this as .unknown
         case is LoadElement,
-             is LoadComputedProperty:
+             is LoadComputedProperty,
+             is CallComputedMethod:
             set(instr.output, .unknown)
 
         case is CallFunction,
@@ -350,9 +353,6 @@ public struct AbstractInterpreter {
 
         case let op as CallMethod:
             set(instr.output, inferMethodSignature(of: op.methodName, on: instr.input(0)).outputType)
-
-        case is CallComputedMethod:
-            set(instr.output, inferMethodSignature(of: instr.input(1).description, on: instr.input(0)).outputType)
 
         case is Construct:
             set(instr.output, inferConstructedType(of: instr.input(0)))

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -593,7 +593,7 @@ extension Instruction: ProtobufConvertible {
         case .callMethod(let p):
             op = CallMethod(methodName: p.methodName, numArguments: inouts.count - 2)
         case .callComputedMethod(_):
-            // We subtract 3 from the inouts count since the first two elements are the callee and method and the last element is the instruction index
+            // We subtract 3 from the inouts count since the first two elements are the callee and method and the last element is the output variable
             op = CallComputedMethod(numArguments: inouts.count - 3)
         case .callFunction(_):
             op = CallFunction(numArguments: inouts.count - 2)

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -137,7 +137,9 @@ public struct Instruction {
         return op.attributes.contains(.isLiteral)
     }
 
-    /// Is this instruction parametric, i.e. contains any mutable values?
+    /// Is this instruction parametric, i.e. can/should this operation be mutated by the OperationMutator?
+    /// The rough rule of thumbs is that every Operation class that has members other than those already in the Operation class are parametric.
+    /// For example integer values (LoadInteger), string values (LoadProperty and CallMethod), or Arrays (CallFunctionWithSpread).
     public var isParametric: Bool {
         return op.attributes.contains(.isParametric)
     }

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -367,6 +367,8 @@ extension Instruction: ProtobufConvertible {
                 $0.await = Fuzzilli_Protobuf_Await()
             case let op as CallMethod:
                 $0.callMethod = Fuzzilli_Protobuf_CallMethod.with { $0.methodName = op.methodName }
+            case let op as CallComputedMethod:
+                $0.callComputedMethod = Fuzzilli_Protobuf_CallComputedMethod.with { $0.methodName = op.methodName }
             case is CallFunction:
                 $0.callFunction = Fuzzilli_Protobuf_CallFunction()
             case is Construct:
@@ -590,6 +592,8 @@ extension Instruction: ProtobufConvertible {
             op = Await()
         case .callMethod(let p):
             op = CallMethod(methodName: p.methodName, numArguments: inouts.count - 2)
+        case .callComputedMethod(let p):
+            op = CallComputedMethod(methodName: p.methodName, numArguments: inouts.count - 2)
         case .callFunction(_):
             op = CallFunction(numArguments: inouts.count - 2)
         case .construct(_):

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -367,8 +367,8 @@ extension Instruction: ProtobufConvertible {
                 $0.await = Fuzzilli_Protobuf_Await()
             case let op as CallMethod:
                 $0.callMethod = Fuzzilli_Protobuf_CallMethod.with { $0.methodName = op.methodName }
-            case let op as CallComputedMethod:
-                $0.callComputedMethod = Fuzzilli_Protobuf_CallComputedMethod.with { $0.methodName = op.methodName }
+            case is CallComputedMethod:
+                $0.callComputedMethod = Fuzzilli_Protobuf_CallComputedMethod()
             case is CallFunction:
                 $0.callFunction = Fuzzilli_Protobuf_CallFunction()
             case is Construct:
@@ -592,8 +592,9 @@ extension Instruction: ProtobufConvertible {
             op = Await()
         case .callMethod(let p):
             op = CallMethod(methodName: p.methodName, numArguments: inouts.count - 2)
-        case .callComputedMethod(let p):
-            op = CallComputedMethod(methodName: p.methodName, numArguments: inouts.count - 2)
+        case .callComputedMethod(_):
+            // We subtract 3 from the inouts count since the first two elements are the callee and method and the last element is the instruction index
+            op = CallComputedMethod(numArguments: inouts.count - 3)
         case .callFunction(_):
             op = CallFunction(numArguments: inouts.count - 2)
         case .construct(_):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -415,6 +415,19 @@ class CallMethod: Operation {
     }
 }
 
+class CallComputedMethod: Operation {
+    let methodName: String
+    var numArguments: Int {
+        return numInputs - 1
+    }
+
+    init(methodName: String, numArguments: Int) {
+        self.methodName = methodName
+        // reference object is the first input
+        super.init(numInputs: numArguments + 1, numOutputs: 1, attributes: [.isParametric, .isVarargs, .isCall])
+    }
+}
+
 class CallFunction: Operation {
     var numArguments: Int {
         return numInputs - 1

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -416,15 +416,13 @@ class CallMethod: Operation {
 }
 
 class CallComputedMethod: Operation {
-    let methodName: String
     var numArguments: Int {
-        return numInputs - 1
+        return numInputs - 2
     }
 
-    init(methodName: String, numArguments: Int) {
-        self.methodName = methodName
-        // reference object is the first input
-        super.init(numInputs: numArguments + 1, numOutputs: 1, attributes: [.isParametric, .isVarargs, .isCall])
+    init(numArguments: Int) {
+        // reference object is the first input and method name is the second input
+        super.init(numInputs: numArguments + 2, numOutputs: 1, attributes: [.isParametric, .isVarargs, .isCall])
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -422,7 +422,7 @@ class CallComputedMethod: Operation {
 
     init(numArguments: Int) {
         // reference object is the first input and method name is the second input
-        super.init(numInputs: numArguments + 2, numOutputs: 1, attributes: [.isParametric, .isVarargs, .isCall])
+        super.init(numInputs: numArguments + 2, numOutputs: 1, attributes: [.isVarargs, .isCall])
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -25,7 +25,8 @@ extension Operation {
         
         switch self {
         case is CallFunction,
-             is CallMethod:
+             is CallMethod,
+             is CallComputedMethod:
             // We assume that a constructor doesn't modify its arguments when called
             return true
         case is StoreProperty,

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -150,6 +150,10 @@ public class FuzzILLifter: Lifter {
             let arguments = instr.inputs.dropFirst().map({ $0.identifier })
             w.emit("\(instr.output) <- CallMethod \(input(0)), '\(op.methodName)', [\(arguments.joined(separator: ", "))]")
 
+        case let op as CallComputedMethod:
+            let arguments = instr.inputs.dropFirst().map({ $0.identifier })
+            w.emit("\(instr.output) <- CallComputedMethod \(input(0)), '\(op.methodName)', [\(arguments.joined(separator: ", "))]")
+
         case is Construct:
             let arguments = instr.inputs.dropFirst().map({ $0.identifier })
             w.emit("\(instr.output) <- Construct \(input(0)), [\(arguments.joined(separator: ", "))]")

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -152,7 +152,7 @@ public class FuzzILLifter: Lifter {
 
         case is CallComputedMethod:
             let arguments = instr.inputs.dropFirst(2).map({ $0.identifier })
-            w.emit("\(instr.output) <- CallComputedMethod \(input(0)), '\(input(1))', [\(arguments.joined(separator: ", "))]")
+            w.emit("\(instr.output) <- CallComputedMethod \(input(0)), \(input(1)), [\(arguments.joined(separator: ", "))]")
 
         case is Construct:
             let arguments = instr.inputs.dropFirst().map({ $0.identifier })

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -150,9 +150,9 @@ public class FuzzILLifter: Lifter {
             let arguments = instr.inputs.dropFirst().map({ $0.identifier })
             w.emit("\(instr.output) <- CallMethod \(input(0)), '\(op.methodName)', [\(arguments.joined(separator: ", "))]")
 
-        case let op as CallComputedMethod:
+        case is CallComputedMethod:
             let arguments = instr.inputs.dropFirst().map({ $0.identifier })
-            w.emit("\(instr.output) <- CallComputedMethod \(input(0)), '\(op.methodName)', [\(arguments.joined(separator: ", "))]")
+            w.emit("\(instr.output) <- CallComputedMethod \(input(0)), '\(input(1))', [\(arguments.joined(separator: ", "))]")
 
         case is Construct:
             let arguments = instr.inputs.dropFirst().map({ $0.identifier })

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -151,7 +151,7 @@ public class FuzzILLifter: Lifter {
             w.emit("\(instr.output) <- CallMethod \(input(0)), '\(op.methodName)', [\(arguments.joined(separator: ", "))]")
 
         case is CallComputedMethod:
-            let arguments = instr.inputs.dropFirst().map({ $0.identifier })
+            let arguments = instr.inputs.dropFirst(2).map({ $0.identifier })
             w.emit("\(instr.output) <- CallComputedMethod \(input(0)), '\(input(1))', [\(arguments.joined(separator: ", "))]")
 
         case is Construct:

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -319,6 +319,11 @@ public class JavaScriptLifter: Lifter {
                 let method = MemberExpression.new() <> input(0) <> "." <> op.methodName
                 output = CallExpression.new() <> method <> "(" <> arguments.joined(separator: ",") <> ")"
 
+            case let op as CallComputedMethod:
+                let arguments = instr.inputs.dropFirst().map({ expr(for: $0).text })
+                let method = MemberExpression.new() <> input(0) <> "[" <> op.methodName <> "]"
+                output = CallExpression.new() <> method <> "(" <> arguments.joined(separator: ",") <> ")"
+
             case is Construct:
                 let arguments = instr.inputs.dropFirst().map({ expr(for: $0).text })
                 output = NewExpression.new() <> "new " <> input(0) <> "(" <> arguments.joined(separator: ",") <> ")"

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -319,9 +319,9 @@ public class JavaScriptLifter: Lifter {
                 let method = MemberExpression.new() <> input(0) <> "." <> op.methodName
                 output = CallExpression.new() <> method <> "(" <> arguments.joined(separator: ",") <> ")"
 
-            case let op as CallComputedMethod:
-                let arguments = instr.inputs.dropFirst().map({ expr(for: $0).text })
-                let method = MemberExpression.new() <> input(0) <> "[" <> op.methodName <> "]"
+            case is CallComputedMethod:
+                let arguments = instr.inputs.dropFirst(2).map({ expr(for: $0).text })
+                let method = MemberExpression.new() <> input(0) <> "[" <> input(1) <> "]"
                 output = CallExpression.new() <> method <> "(" <> arguments.joined(separator: ",") <> ")"
 
             case is Construct:

--- a/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
+++ b/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
@@ -47,8 +47,8 @@ struct CallArgumentReducer: Reducer {
                     break
                 }
 
-                let newOp = CallComputedMethod(methodName: op.methodName, numArguments: op.numArguments - 1)
-                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
+                let newOp = CallComputedMethod(numArguments: op.numArguments - 2)
+                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast(2)))
                 verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
                 
             case let op as Construct:

--- a/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
+++ b/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
@@ -47,8 +47,8 @@ struct CallArgumentReducer: Reducer {
                     break
                 }
 
-                let newOp = CallComputedMethod(numArguments: op.numArguments - 2)
-                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast(2)))
+                let newOp = CallComputedMethod(numArguments: op.numArguments - 1)
+                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
                 verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
                 
             case let op as Construct:

--- a/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
+++ b/Sources/Fuzzilli/Minimization/CallArgumentReducer.swift
@@ -41,6 +41,15 @@ struct CallArgumentReducer: Reducer {
                 let newOp = CallMethod(methodName: op.methodName, numArguments: op.numArguments - 1)
                 let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
                 verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
+
+            case let op as CallComputedMethod:
+                guard op.numArguments > minArgCount else {
+                    break
+                }
+
+                let newOp = CallComputedMethod(methodName: op.methodName, numArguments: op.numArguments - 1)
+                let newInstr = Instruction(newOp, output: instr.output, inputs: Array(instr.inputs.dropLast()))
+                verifier.tryReplacing(instructionAt: instr.index, with: newInstr, in: &code)
                 
             case let op as Construct:
                 guard op.numArguments > minArgCount else {

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -80,7 +80,7 @@ public class OperationMutator: BaseInstructionMutator {
         case let op as CallMethod:
             newOp = CallMethod(methodName: b.genMethodName(), numArguments: op.numArguments)
         case let op as CallComputedMethod:
-            newOp = CallComputedMethod(methodName: b.genMethodName(), numArguments: op.numArguments)
+            newOp = CallComputedMethod(numArguments: op.numArguments)
         case let op as CallFunctionWithSpread:
             var spreads = op.spreads
             if spreads.count > 0 {

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -79,6 +79,8 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = DeleteElement(index: b.genIndex())
         case let op as CallMethod:
             newOp = CallMethod(methodName: b.genMethodName(), numArguments: op.numArguments)
+        case let op as CallComputedMethod:
+            newOp = CallComputedMethod(methodName: b.genMethodName(), numArguments: op.numArguments)
         case let op as CallFunctionWithSpread:
             var spreads = op.spreads
             if spreads.count > 0 {

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -79,8 +79,6 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = DeleteElement(index: b.genIndex())
         case let op as CallMethod:
             newOp = CallMethod(methodName: b.genMethodName(), numArguments: op.numArguments)
-        case let op as CallComputedMethod:
-            newOp = CallComputedMethod(numArguments: op.numArguments)
         case let op as CallFunctionWithSpread:
             var spreads = op.spreads
             if spreads.count > 0 {

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -803,6 +803,18 @@ public struct Fuzzilli_Protobuf_CallMethod {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_CallComputedMethod {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var methodName: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_CallFunction {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -2490,6 +2502,38 @@ extension Fuzzilli_Protobuf_CallMethod: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_CallMethod, rhs: Fuzzilli_Protobuf_CallMethod) -> Bool {
+    if lhs.methodName != rhs.methodName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_CallComputedMethod: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CallComputedMethod"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "methodName"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.methodName) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.methodName.isEmpty {
+      try visitor.visitSingularStringField(value: self.methodName, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_CallComputedMethod, rhs: Fuzzilli_Protobuf_CallComputedMethod) -> Bool {
     if lhs.methodName != rhs.methodName {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -808,8 +808,6 @@ public struct Fuzzilli_Protobuf_CallComputedMethod {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var methodName: String = String()
-
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -2510,31 +2508,18 @@ extension Fuzzilli_Protobuf_CallMethod: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Fuzzilli_Protobuf_CallComputedMethod: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CallComputedMethod"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "methodName"),
-  ]
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.methodName) }()
-      default: break
-      }
+    while let _ = try decoder.nextFieldNumber() {
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.methodName.isEmpty {
-      try visitor.visitSingularStringField(value: self.methodName, fieldNumber: 1)
-    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_CallComputedMethod, rhs: Fuzzilli_Protobuf_CallComputedMethod) -> Bool {
-    if lhs.methodName != rhs.methodName {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -175,7 +175,6 @@ message CallMethod {
 }
 
 message CallComputedMethod {
-    string methodName = 1;
 }
 
 message CallFunction {

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -174,6 +174,10 @@ message CallMethod {
     string methodName = 1;
 }
 
+message CallComputedMethod {
+    string methodName = 1;
+}
+
 message CallFunction {
 }
 

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -497,6 +497,14 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .callMethod(newValue)}
   }
 
+  public var callComputedMethod: Fuzzilli_Protobuf_CallComputedMethod {
+    get {
+      if case .callComputedMethod(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_CallComputedMethod()
+    }
+    set {operation = .callComputedMethod(newValue)}
+  }
+
   public var callFunction: Fuzzilli_Protobuf_CallFunction {
     get {
       if case .callFunction(let v)? = operation {return v}
@@ -906,6 +914,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case yieldEach(Fuzzilli_Protobuf_YieldEach)
     case await(Fuzzilli_Protobuf_Await)
     case callMethod(Fuzzilli_Protobuf_CallMethod)
+    case callComputedMethod(Fuzzilli_Protobuf_CallComputedMethod)
     case callFunction(Fuzzilli_Protobuf_CallFunction)
     case construct(Fuzzilli_Protobuf_Construct)
     case callFunctionWithSpread(Fuzzilli_Protobuf_CallFunctionWithSpread)
@@ -1136,6 +1145,10 @@ public struct Fuzzilli_Protobuf_Instruction {
       }()
       case (.callMethod, .callMethod): return {
         guard case .callMethod(let l) = lhs, case .callMethod(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.callComputedMethod, .callComputedMethod): return {
+        guard case .callComputedMethod(let l) = lhs, case .callComputedMethod(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.callFunction, .callFunction): return {
@@ -1477,6 +1490,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     74: .same(proto: "yieldEach"),
     75: .same(proto: "await"),
     31: .same(proto: "callMethod"),
+    96: .same(proto: "callComputedMethod"),
     32: .same(proto: "callFunction"),
     33: .same(proto: "construct"),
     34: .same(proto: "callFunctionWithSpread"),
@@ -2338,6 +2352,15 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {self.operation = .beginFinally(v)}
       }()
+      case 96: try {
+        var v: Fuzzilli_Protobuf_CallComputedMethod?
+        if let current = self.operation {
+          try decoder.handleConflictingOneOf()
+          if case .callComputedMethod(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.operation = .callComputedMethod(v)}
+      }()
       default: break
       }
     }
@@ -2710,6 +2733,10 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .beginFinally?: try {
       guard case .beginFinally(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 95)
+    }()
+    case .callComputedMethod?: try {
+      guard case .callComputedMethod(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 96)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -70,6 +70,7 @@ message Instruction {
         YieldEach yieldEach = 74;
         Await await = 75;
         CallMethod callMethod = 31;
+        CallComputedMethod callComputedMethod = 96;
         CallFunction callFunction = 32;
         Construct construct = 33;
         CallFunctionWithSpread callFunctionWithSpread = 34;

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -55,7 +55,7 @@ let codeGeneratorWeights = [
     "FunctionCallGenerator":                30,
     "FunctionCallWithSpreadGenerator":      10,
     "MethodCallGenerator":                  40,
-    "ComputedMethodCallGenerator":          5,
+    "ComputedMethodCallGenerator":          50,
     "ConstructorCallGenerator":             25,
     "UnaryOperationGenerator":              25,
     "BinaryOperationGenerator":             40,

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -55,6 +55,7 @@ let codeGeneratorWeights = [
     "FunctionCallGenerator":                30,
     "FunctionCallWithSpreadGenerator":      10,
     "MethodCallGenerator":                  40,
+    "ComputedMethodCallGenerator":          5,
     "ConstructorCallGenerator":             25,
     "UnaryOperationGenerator":              25,
     "BinaryOperationGenerator":             40,

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -55,7 +55,7 @@ let codeGeneratorWeights = [
     "FunctionCallGenerator":                30,
     "FunctionCallWithSpreadGenerator":      10,
     "MethodCallGenerator":                  40,
-    "ComputedMethodCallGenerator":          50,
+    "ComputedMethodCallGenerator":          10,
     "ConstructorCallGenerator":             25,
     "UnaryOperationGenerator":              25,
     "BinaryOperationGenerator":             40,

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -517,23 +517,19 @@ class LifterTests: XCTestCase {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
-        let v0 = b.loadString("Hello")
-        //added to prevent inlining
-        b.reassign(v0, to: b.loadString("World"))
+        let v0 = b.loadString("Hello World")
         let v2 = b.loadBuiltin("Symbol")
-        let _ = b.loadProperty("iterator", of: v2)
-        let v4 = b.callComputedMethod("v3", on: v0, withArgs: [])
+        let v3 = b.loadProperty("iterator", of: v2)
+        let v4 = b.callComputedMethod(v3, on: v0, withArgs: [])
         let _ = b.callMethod("next", on: v4, withArgs: [])
 
         let program = b.finalize()
 
         let lifted_program = fuzzer.lifter.lift(program)
         let expected_program = """
-        let v0 = "Hello";
-        v0 = "World";
-        const v3 = Symbol.iterator;
-        const v4 = v0[v3]();
-        const v5 = v4.next();
+        const v2 = Symbol.iterator;
+        const v3 = "Hello World"[v2]();
+        const v4 = v3.next();
 
         """
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -518,10 +518,10 @@ class LifterTests: XCTestCase {
         let b = fuzzer.makeBuilder()
 
         let v0 = b.loadString("Hello World")
-        let v2 = b.loadBuiltin("Symbol")
-        let v3 = b.loadProperty("iterator", of: v2)
-        let v4 = b.callComputedMethod(v3, on: v0, withArgs: [])
-        let _ = b.callMethod("next", on: v4, withArgs: [])
+        let v1 = b.loadBuiltin("Symbol")
+        let v2 = b.loadProperty("iterator", of: v1)
+        let v3 = b.callComputedMethod(v2, on: v0, withArgs: [])
+        let _ = b.callMethod("next", on: v3, withArgs: [])
 
         let program = b.finalize()
 

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -63,6 +63,7 @@ extension LifterTests {
         ("testTryCatchFinallyLifting", testTryCatchFinallyLifting),
         ("testTryCatchLifting", testTryCatchLifting),
         ("testTryFinallyLifting", testTryFinallyLifting),
+        ("testComputedMethodLifting", testComputedMethodLifting),
     ]
 }
 


### PR DESCRIPTION
This PR adds support to generating computed method calls to fuzzilli. This would now allow generating JS of the form:
 ```
let v = callee[method](arguments)
```
An example of this usecase would be the use of `Symbol.iterator` demonstrated in this [JSC testcase](https://github.com/WebKit/WebKit/blob/main/JSTests/stress/arguments-iterator.js#L36)