### PR TITLE
Add assignment operators

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -308,9 +308,9 @@ public let CodeGenerators: [CodeGenerator] = [
         b.binary(lhs, rhs, with: chooseUniform(from: allBinaryOperators))
     },
     
-    CodeGenerator("AssignmentOperationGenerator", input: .anything) { b, val in
+    CodeGenerator("BinaryOperationAndReassignGenerator", input: .anything) { b, val in
         let target = b.randVar()
-        b.assign(target, to: val, with: chooseUniform(from: allBinaryOperators))
+        b.binaryOpAndReassign(target, to: val, with: chooseUniform(from: allBinaryOperators))
     },
 
     CodeGenerator("DupGenerator") { b in

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -308,6 +308,11 @@ public let CodeGenerators: [CodeGenerator] = [
         b.binary(lhs, rhs, with: chooseUniform(from: allBinaryOperators))
     },
     
+    CodeGenerator("AssignmentOperationGenerator", input: .anything) { b, val in
+        let target = b.randVar()
+        b.assign(target, to: val, with: chooseUniform(from: allBinaryOperators))
+    },
+
     CodeGenerator("DupGenerator") { b in
         b.dup(b.randVar())
     },

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1165,8 +1165,8 @@ public class ProgramBuilder {
         return perform(BinaryOperation(op), withInputs: [lhs, rhs]).output
     }
 
-    public func assign(_ output: Variable, to input: Variable, with op: BinaryOperator) {
-        perform(AssignmentOperation(op), withInputs: [output, input])
+    public func binaryOpAndReassign(_ output: Variable, to input: Variable, with op: BinaryOperator) {
+        perform(BinaryOperationAndReassign(op), withInputs: [output, input])
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1165,6 +1165,10 @@ public class ProgramBuilder {
         return perform(BinaryOperation(op), withInputs: [lhs, rhs]).output
     }
 
+    public func assign(_ output: Variable, to input: Variable, with op: BinaryOperator) {
+        perform(AssignmentOperation(op), withInputs: [output, input])
+    }
+
     @discardableResult
     public func dup(_ v: Variable) -> Variable {
         return perform(Dup(), withInputs: [v]).output

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -430,6 +430,28 @@ public struct AbstractInterpreter {
                 set(instr.output, .boolean)
             }
 
+        case let op as AssignmentOperation:
+            switch op.op {
+            case .Add:
+                set(instr.input(0), .primitive)
+            case .Sub,
+                 .Mul,
+                 .Exp,
+                 .Div,
+                 .Mod:
+                set(instr.input(0), .number | .bigint)
+            case .BitAnd,
+                 .BitOr,
+                 .Xor,
+                 .LShift,
+                 .RShift,
+                 .UnRShift:
+                set(instr.input(0), .integer | .bigint)
+            case .LogicAnd,
+                 .LogicOr:
+                set(instr.input(0), .boolean)
+            }
+
         case is TypeOf:
             set(instr.output, .string)
 

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -430,23 +430,23 @@ public struct AbstractInterpreter {
                 set(instr.output, .boolean)
             }
 
-        case let op as AssignmentOperation:
+        case let op as BinaryOperationAndReassign:
             switch op.op {
             case .Add:
-                set(instr.input(0), .primitive)
+                set(instr.input(0), maybeBigIntOr(.primitive))
             case .Sub,
                  .Mul,
                  .Exp,
                  .Div,
                  .Mod:
-                set(instr.input(0), .number | .bigint)
+                set(instr.input(0), maybeBigIntOr(.number))
             case .BitAnd,
                  .BitOr,
                  .Xor,
                  .LShift,
                  .RShift,
                  .UnRShift:
-                set(instr.input(0), .integer | .bigint)
+                set(instr.input(0), maybeBigIntOr(.integer))
             case .LogicAnd,
                  .LogicOr:
                 set(instr.input(0), .boolean)

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -366,6 +366,8 @@ extension Instruction: ProtobufConvertible {
                 $0.unaryOperation = Fuzzilli_Protobuf_UnaryOperation.with { $0.op = convertEnum(op.op, allUnaryOperators) }
             case let op as BinaryOperation:
                 $0.binaryOperation = Fuzzilli_Protobuf_BinaryOperation.with { $0.op = convertEnum(op.op, allBinaryOperators) }
+            case let op as AssignmentOperation:
+                $0.assignmentOperation = Fuzzilli_Protobuf_AssignmentOperation.with { $0.op = convertEnum(op.op, allBinaryOperators) }
             case is Dup:
                 $0.dup = Fuzzilli_Protobuf_Dup()
             case is Reassign:
@@ -594,6 +596,8 @@ extension Instruction: ProtobufConvertible {
             op = UnaryOperation(try convertEnum(p.op, allUnaryOperators))
         case .binaryOperation(let p):
             op = BinaryOperation(try convertEnum(p.op, allBinaryOperators))
+        case .assignmentOperation(let p):
+            op = AssignmentOperation(try convertEnum(p.op, allBinaryOperators))
         case .dup(_):
             op = Dup()
         case .reassign(_):

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -366,8 +366,8 @@ extension Instruction: ProtobufConvertible {
                 $0.unaryOperation = Fuzzilli_Protobuf_UnaryOperation.with { $0.op = convertEnum(op.op, allUnaryOperators) }
             case let op as BinaryOperation:
                 $0.binaryOperation = Fuzzilli_Protobuf_BinaryOperation.with { $0.op = convertEnum(op.op, allBinaryOperators) }
-            case let op as AssignmentOperation:
-                $0.assignmentOperation = Fuzzilli_Protobuf_AssignmentOperation.with { $0.op = convertEnum(op.op, allBinaryOperators) }
+            case let op as BinaryOperationAndReassign:
+                $0.binaryOperationAndReassign = Fuzzilli_Protobuf_BinaryOperationAndReassign.with { $0.op = convertEnum(op.op, allBinaryOperators) }
             case is Dup:
                 $0.dup = Fuzzilli_Protobuf_Dup()
             case is Reassign:
@@ -596,8 +596,8 @@ extension Instruction: ProtobufConvertible {
             op = UnaryOperation(try convertEnum(p.op, allUnaryOperators))
         case .binaryOperation(let p):
             op = BinaryOperation(try convertEnum(p.op, allBinaryOperators))
-        case .assignmentOperation(let p):
-            op = AssignmentOperation(try convertEnum(p.op, allBinaryOperators))
+        case .binaryOperationAndReassign(let p):
+            op = BinaryOperationAndReassign(try convertEnum(p.op, allBinaryOperators))
         case .dup(_):
             op = Dup()
         case .reassign(_):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -546,7 +546,7 @@ class BinaryOperation: Operation {
 }
 
 /// Assigns a value to its left operand based on the value of its right operand.
-class AssignmentOperation: Operation {
+class BinaryOperationAndReassign: Operation {
     let op: BinaryOperator
 
     init(_ op: BinaryOperator) {

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -545,6 +545,16 @@ class BinaryOperation: Operation {
     }
 }
 
+/// Assigns a value to its left operand based on the value of its right operand.
+class AssignmentOperation: Operation {
+    let op: BinaryOperator
+
+    init(_ op: BinaryOperator) {
+        self.op = op
+        super.init(numInputs: 2, numOutputs: 0)
+    }
+}
+
 /// Duplicates a variable, essentially doing `output = input;`
 class Dup: Operation {
     init() {

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -40,7 +40,8 @@ extension Operation {
     
     func reassigns(input inputIdx: Int) -> Bool {
         switch self {
-        case is Reassign:
+        case is Reassign,
+             is BinaryOperationAndReassign:
             return inputIdx == 0
         case let op as UnaryOperation:
             return op.op.reassignsInput

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -179,6 +179,9 @@ public class FuzzILLifter: Lifter {
         case let op as BinaryOperation:
             w.emit("\(instr.output) <- BinaryOperation \(input(0)), '\(op.op.token)', \(input(1))")
 
+        case let op as AssignmentOperation:
+            w.emit("\(instr.input(0)) <- AssignmentOperation '\(op.op.token)', \(input(1))")
+
         case is Dup:
             w.emit("\(instr.output) <- Dup \(input(0))")
 

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -179,8 +179,8 @@ public class FuzzILLifter: Lifter {
         case let op as BinaryOperation:
             w.emit("\(instr.output) <- BinaryOperation \(input(0)), '\(op.op.token)', \(input(1))")
 
-        case let op as AssignmentOperation:
-            w.emit("\(instr.input(0)) <- AssignmentOperation '\(op.op.token)', \(input(1))")
+        case let op as BinaryOperationAndReassign:
+            w.emit("\(instr.input(0)) <- BinaryOperationAndReassign '\(op.op.token)', \(input(1))")
 
         case is Dup:
             w.emit("\(instr.output) <- Dup \(input(0))")

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -349,7 +349,7 @@ public class JavaScriptLifter: Lifter {
             case let op as BinaryOperation:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)
 
-            case let op as AssignmentOperation:
+            case let op as BinaryOperationAndReassign:
                 w.emit("\(input(0)) \(op.op.token)= \(input(1));")
 
             case is Dup:

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -349,6 +349,9 @@ public class JavaScriptLifter: Lifter {
             case let op as BinaryOperation:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)
 
+            case let op as AssignmentOperation:
+                w.emit("\(input(0)) \(op.op.token)= \(input(1));")
+
             case is Dup:
                 w.emit("\(decl(instr.output)) = \(input(0));")
 

--- a/Sources/Fuzzilli/Lifting/TypeCollectionAnalyzer.swift
+++ b/Sources/Fuzzilli/Lifting/TypeCollectionAnalyzer.swift
@@ -21,7 +21,7 @@ struct TypeCollectionAnalyzer {
     func analyze(_ instr: Instruction) -> [Variable] {
         switch instr.op {
             case is LoadInteger, is LoadBigInt, is LoadFloat, is LoadBoolean, is LoadNull, is LoadUndefined,
-                 is TypeOf, is InstanceOf, is In, is Dup, is Reassign, is Compare, is BeginForIn:
+                 is TypeOf, is InstanceOf, is In, is Dup, is Reassign, is BinaryOperationAndReassign, is Compare, is BeginForIn:
                 // No need to collect types for instructions interpreter can handle
                 return []
             case is BeginAnyFunctionDefinition:

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -90,6 +90,8 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = UnaryOperation(chooseUniform(from: allUnaryOperators))
         case is BinaryOperation:
             newOp = BinaryOperation(chooseUniform(from: allBinaryOperators))
+        case is AssignmentOperation:
+            newOp = AssignmentOperation(chooseUniform(from: allBinaryOperators))
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))
         case is LoadFromScope:

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -90,8 +90,8 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = UnaryOperation(chooseUniform(from: allUnaryOperators))
         case is BinaryOperation:
             newOp = BinaryOperation(chooseUniform(from: allBinaryOperators))
-        case is AssignmentOperation:
-            newOp = AssignmentOperation(chooseUniform(from: allBinaryOperators))
+        case is BinaryOperationAndReassign:
+            newOp = BinaryOperationAndReassign(chooseUniform(from: allBinaryOperators))
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))
         case is LoadFromScope:

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -869,7 +869,7 @@ public struct Fuzzilli_Protobuf_BinaryOperation {
   public init() {}
 }
 
-public struct Fuzzilli_Protobuf_AssignmentOperation {
+public struct Fuzzilli_Protobuf_BinaryOperationAndReassign {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2681,8 +2681,8 @@ extension Fuzzilli_Protobuf_BinaryOperation: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Fuzzilli_Protobuf_AssignmentOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".AssignmentOperation"
+extension Fuzzilli_Protobuf_BinaryOperationAndReassign: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".BinaryOperationAndReassign"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "op"),
   ]
@@ -2706,7 +2706,7 @@ extension Fuzzilli_Protobuf_AssignmentOperation: SwiftProtobuf.Message, SwiftPro
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Fuzzilli_Protobuf_AssignmentOperation, rhs: Fuzzilli_Protobuf_AssignmentOperation) -> Bool {
+  public static func ==(lhs: Fuzzilli_Protobuf_BinaryOperationAndReassign, rhs: Fuzzilli_Protobuf_BinaryOperationAndReassign) -> Bool {
     if lhs.op != rhs.op {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -869,6 +869,18 @@ public struct Fuzzilli_Protobuf_BinaryOperation {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_AssignmentOperation {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var op: Fuzzilli_Protobuf_BinaryOperator = .add
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_Dup {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -2663,6 +2675,38 @@ extension Fuzzilli_Protobuf_BinaryOperation: SwiftProtobuf.Message, SwiftProtobu
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_BinaryOperation, rhs: Fuzzilli_Protobuf_BinaryOperation) -> Bool {
+    if lhs.op != rhs.op {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_AssignmentOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AssignmentOperation"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "op"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.op) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.op != .add {
+      try visitor.visitSingularEnumField(value: self.op, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_AssignmentOperation, rhs: Fuzzilli_Protobuf_AssignmentOperation) -> Bool {
     if lhs.op != rhs.op {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -223,6 +223,10 @@ message BinaryOperation {
     BinaryOperator op = 1;
 }
 
+message AssignmentOperation {
+    BinaryOperator op = 1;
+}
+
 message Dup {
 }
 

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -223,7 +223,7 @@ message BinaryOperation {
     BinaryOperator op = 1;
 }
 
-message AssignmentOperation {
+message BinaryOperationAndReassign {
     BinaryOperator op = 1;
 }
 

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -545,6 +545,14 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .binaryOperation(newValue)}
   }
 
+  public var assignmentOperation: Fuzzilli_Protobuf_AssignmentOperation {
+    get {
+      if case .assignmentOperation(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_AssignmentOperation()
+    }
+    set {operation = .assignmentOperation(newValue)}
+  }
+
   public var dup: Fuzzilli_Protobuf_Dup {
     get {
       if case .dup(let v)? = operation {return v}
@@ -928,6 +936,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case callFunctionWithSpread(Fuzzilli_Protobuf_CallFunctionWithSpread)
     case unaryOperation(Fuzzilli_Protobuf_UnaryOperation)
     case binaryOperation(Fuzzilli_Protobuf_BinaryOperation)
+    case assignmentOperation(Fuzzilli_Protobuf_AssignmentOperation)
     case dup(Fuzzilli_Protobuf_Dup)
     case reassign(Fuzzilli_Protobuf_Reassign)
     case compare(Fuzzilli_Protobuf_Compare)
@@ -1178,6 +1187,10 @@ public struct Fuzzilli_Protobuf_Instruction {
       }()
       case (.binaryOperation, .binaryOperation): return {
         guard case .binaryOperation(let l) = lhs, case .binaryOperation(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.assignmentOperation, .assignmentOperation): return {
+        guard case .assignmentOperation(let l) = lhs, case .assignmentOperation(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.dup, .dup): return {
@@ -1509,6 +1522,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     34: .same(proto: "callFunctionWithSpread"),
     35: .same(proto: "unaryOperation"),
     36: .same(proto: "binaryOperation"),
+    97: .same(proto: "assignmentOperation"),
     37: .same(proto: "dup"),
     38: .same(proto: "reassign"),
     39: .same(proto: "compare"),
@@ -2384,6 +2398,15 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {self.operation = .conditionalOperation(v)}
       }()
+      case 97: try {
+        var v: Fuzzilli_Protobuf_AssignmentOperation?
+        if let current = self.operation {
+          try decoder.handleConflictingOneOf()
+          if case .assignmentOperation(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.operation = .assignmentOperation(v)}
+      }()
       default: break
       }
     }
@@ -2764,6 +2787,10 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .conditionalOperation?: try {
       guard case .conditionalOperation(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 98)
+    }()
+    case .assignmentOperation?: try {
+      guard case .assignmentOperation(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 97)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -545,12 +545,12 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .binaryOperation(newValue)}
   }
 
-  public var assignmentOperation: Fuzzilli_Protobuf_AssignmentOperation {
+  public var binaryOperationAndReassign: Fuzzilli_Protobuf_BinaryOperationAndReassign {
     get {
-      if case .assignmentOperation(let v)? = operation {return v}
-      return Fuzzilli_Protobuf_AssignmentOperation()
+      if case .binaryOperationAndReassign(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_BinaryOperationAndReassign()
     }
-    set {operation = .assignmentOperation(newValue)}
+    set {operation = .binaryOperationAndReassign(newValue)}
   }
 
   public var dup: Fuzzilli_Protobuf_Dup {
@@ -936,7 +936,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case callFunctionWithSpread(Fuzzilli_Protobuf_CallFunctionWithSpread)
     case unaryOperation(Fuzzilli_Protobuf_UnaryOperation)
     case binaryOperation(Fuzzilli_Protobuf_BinaryOperation)
-    case assignmentOperation(Fuzzilli_Protobuf_AssignmentOperation)
+    case binaryOperationAndReassign(Fuzzilli_Protobuf_BinaryOperationAndReassign)
     case dup(Fuzzilli_Protobuf_Dup)
     case reassign(Fuzzilli_Protobuf_Reassign)
     case compare(Fuzzilli_Protobuf_Compare)
@@ -1189,8 +1189,8 @@ public struct Fuzzilli_Protobuf_Instruction {
         guard case .binaryOperation(let l) = lhs, case .binaryOperation(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.assignmentOperation, .assignmentOperation): return {
-        guard case .assignmentOperation(let l) = lhs, case .assignmentOperation(let r) = rhs else { preconditionFailure() }
+      case (.binaryOperationAndReassign, .binaryOperationAndReassign): return {
+        guard case .binaryOperationAndReassign(let l) = lhs, case .binaryOperationAndReassign(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.dup, .dup): return {
@@ -1522,7 +1522,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     34: .same(proto: "callFunctionWithSpread"),
     35: .same(proto: "unaryOperation"),
     36: .same(proto: "binaryOperation"),
-    97: .same(proto: "assignmentOperation"),
+    97: .same(proto: "binaryOperationAndReassign"),
     37: .same(proto: "dup"),
     38: .same(proto: "reassign"),
     39: .same(proto: "compare"),
@@ -2389,6 +2389,15 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {self.operation = .callComputedMethod(v)}
       }()
+      case 97: try {
+        var v: Fuzzilli_Protobuf_BinaryOperationAndReassign?
+        if let current = self.operation {
+          try decoder.handleConflictingOneOf()
+          if case .binaryOperationAndReassign(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.operation = .binaryOperationAndReassign(v)}
+      }()
       case 98: try {
         var v: Fuzzilli_Protobuf_ConditionalOperation?
         if let current = self.operation {
@@ -2397,15 +2406,6 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         }
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {self.operation = .conditionalOperation(v)}
-      }()
-      case 97: try {
-        var v: Fuzzilli_Protobuf_AssignmentOperation?
-        if let current = self.operation {
-          try decoder.handleConflictingOneOf()
-          if case .assignmentOperation(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.operation = .assignmentOperation(v)}
       }()
       default: break
       }
@@ -2784,13 +2784,13 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
       guard case .callComputedMethod(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 96)
     }()
+    case .binaryOperationAndReassign?: try {
+      guard case .binaryOperationAndReassign(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 97)
+    }()
     case .conditionalOperation?: try {
       guard case .conditionalOperation(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 98)
-    }()
-    case .assignmentOperation?: try {
-      guard case .assignmentOperation(let v)? = self.operation else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 97)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -76,6 +76,7 @@ message Instruction {
         CallFunctionWithSpread callFunctionWithSpread = 34;
         UnaryOperation unaryOperation = 35;
         BinaryOperation binaryOperation = 36;
+        AssignmentOperation assignmentOperation = 97;
         Dup dup = 37;
         Reassign reassign = 38;
         Compare compare = 39;

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -76,7 +76,7 @@ message Instruction {
         CallFunctionWithSpread callFunctionWithSpread = 34;
         UnaryOperation unaryOperation = 35;
         BinaryOperation binaryOperation = 36;
-        AssignmentOperation assignmentOperation = 97;
+        BinaryOperationAndReassign binaryOperationAndReassign = 97;
         Dup dup = 37;
         Reassign reassign = 38;
         Compare compare = 39;

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -59,6 +59,7 @@ let codeGeneratorWeights = [
     "ConstructorCallGenerator":             25,
     "UnaryOperationGenerator":              25,
     "BinaryOperationGenerator":             40,
+    "AssignmentOperationGenerator":         25,
     "DupGenerator":                         2,
     "ReassignmentGenerator":                25,
     "WithStatementGenerator":               5,

--- a/Tests/FuzzilliTests/InterpreterTest.swift
+++ b/Tests/FuzzilliTests/InterpreterTest.swift
@@ -638,6 +638,21 @@ class AbstractInterpreterTests: XCTestCase {
             let r3 = b.binary(bi1, bi2, with: op)
             XCTAssert(b.type(of: r3).Is(.bigint))
         }
+
+        for op in allBinaryOperators {
+            // Logical operators produce .boolean in any case
+            guard op != .LogicOr && op != .LogicAnd else { continue }
+            b.binaryOpAndReassign(i1, to: i2, with: op)
+            XCTAssertFalse(b.type(of: i1).MayBe(.bigint))
+            b.binaryOpAndReassign(i1, to: bi2, with: op)
+            print(b.type(of: i1))
+            // This isn't really necessary, as mixing types in this way
+            // would lead to an exception in JS. Currently, we handle
+            // it like this though.
+            XCTAssert(b.type(of: i1).MayBe(.bigint))
+            b.binaryOpAndReassign(bi1, to: bi2, with: op)
+            XCTAssert(b.type(of: bi1).Is(.bigint))
+        }
     }
 }
 

--- a/Tests/FuzzilliTests/InterpreterTest.swift
+++ b/Tests/FuzzilliTests/InterpreterTest.swift
@@ -640,18 +640,25 @@ class AbstractInterpreterTests: XCTestCase {
         }
 
         for op in allBinaryOperators {
+            let i3 = b.loadInt(45)
+            let i4 = b.loadInt(46)
+            XCTAssert(b.type(of: i3).Is(.integer))
+            let bi3 = b.loadBigInt(4200000000)
+            let bi4 = b.loadBigInt(4300000000)
+            XCTAssert(b.type(of: bi3).Is(.bigint))
+
             // Logical operators produce .boolean in any case
             guard op != .LogicOr && op != .LogicAnd else { continue }
-            b.binaryOpAndReassign(i1, to: i2, with: op)
-            XCTAssertFalse(b.type(of: i1).MayBe(.bigint))
-            b.binaryOpAndReassign(i1, to: bi2, with: op)
-            print(b.type(of: i1))
+            b.binaryOpAndReassign(i3, to: i4, with: op)
+            XCTAssertFalse(b.type(of: i3).MayBe(.bigint))
+            b.binaryOpAndReassign(i3, to: bi4, with: op)
+            print(b.type(of: i3))
             // This isn't really necessary, as mixing types in this way
             // would lead to an exception in JS. Currently, we handle
             // it like this though.
-            XCTAssert(b.type(of: i1).MayBe(.bigint))
-            b.binaryOpAndReassign(bi1, to: bi2, with: op)
-            XCTAssert(b.type(of: bi1).Is(.bigint))
+            XCTAssert(b.type(of: i3).MayBe(.bigint))
+            b.binaryOpAndReassign(bi3, to: bi4, with: op)
+            XCTAssert(b.type(of: bi3).Is(.bigint))
         }
     }
 }

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -546,6 +546,35 @@ class LifterTests: XCTestCase {
         let v4 = b.compare(v2, v3, with: .greaterThan)
         let _ = b.conditional(v4, v2, v3)
 
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        const v1 = {a:1337};
+        const v2 = v1.a;
+        const v4 = v2 > 10;
+        const v5 = v4 ? v2 : 10;
+
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
+
+    func testAssignmentOperationLifting(){
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let v0 = b.loadInt(1337)
+        let v1 = b.loadFloat(13.37)
+        b.reassign(v0, to: v1)
+        b.assign(v0, to: v1, with: .Add)
+        b.assign(v0, to: v1, with: .Mul)
+        b.assign(v0, to: v1, with: .LShift)
+
+        let v2 = b.loadString("")
+        let v3 = b.loadString("hello")
+        b.reassign(v2, to: v3)
+        let v4 = b.loadString("world")
+        b.assign(v2, to: v4, with: .Add)
+
         let program = b.finalize()
 
         let lifted_program = fuzzer.lifter.lift(program)
@@ -554,6 +583,14 @@ class LifterTests: XCTestCase {
         const v2 = v1.a;
         const v4 = v2 > 10;
         const v5 = v4 ? v2 : 10;
+        let v0 = 1337;
+        v0 = 13.37;
+        v0 += 13.37;
+        v0 *= 13.37;
+        v0 <<= 13.37;
+        let v2 = "";
+        v2 = "hello";
+        v2 += "world";
 
         """
 
@@ -578,6 +615,7 @@ extension LifterTests {
             ("testTryFinallyLifting", testTryFinallyLifting),
             ("testComputedMethodLifting", testComputedMethodLifting),
             ("testConditionalOperationLifting", testConditionalOperationLifting),
+            ("testAssignmentOperationLifting", testAssignmentOperationLifting),
         ]
     }
 }

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -546,6 +546,8 @@ class LifterTests: XCTestCase {
         let v4 = b.compare(v2, v3, with: .greaterThan)
         let _ = b.conditional(v4, v2, v3)
 
+        let program = b.finalize()
+
         let lifted_program = fuzzer.lifter.lift(program)
         let expected_program = """
         const v1 = {a:1337};
@@ -558,39 +560,65 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testAssignmentOperationLifting(){
+    func testBinaryOperationReassignLifting(){
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
         let v0 = b.loadInt(1337)
         let v1 = b.loadFloat(13.37)
-        b.reassign(v0, to: v1)
-        b.assign(v0, to: v1, with: .Add)
-        b.assign(v0, to: v1, with: .Mul)
-        b.assign(v0, to: v1, with: .LShift)
+        b.binaryOpAndReassign(v0, to: v1, with: .Add)
+        b.binaryOpAndReassign(v0, to: v1, with: .Mul)
+        b.binaryOpAndReassign(v0, to: v1, with: .LShift)
 
-        let v2 = b.loadString("")
-        let v3 = b.loadString("hello")
-        b.reassign(v2, to: v3)
-        let v4 = b.loadString("world")
-        b.assign(v2, to: v4, with: .Add)
+        let v2 = b.loadString("hello")
+        let v3 = b.loadString("world")
+        b.binaryOpAndReassign(v2, to: v3, with: .Add)
 
         let program = b.finalize()
 
         let lifted_program = fuzzer.lifter.lift(program)
         let expected_program = """
-        const v1 = {a:1337};
-        const v2 = v1.a;
-        const v4 = v2 > 10;
-        const v5 = v4 ? v2 : 10;
         let v0 = 1337;
-        v0 = 13.37;
         v0 += 13.37;
         v0 *= 13.37;
         v0 <<= 13.37;
-        let v2 = "";
-        v2 = "hello";
+        let v2 = "hello";
         v2 += "world";
+
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
+
+    /// Verifies that all variables that are reassigned through either
+    ///
+    /// a .PostInc and .PreInc UnaryOperation,
+    /// a Reassign instruction, or
+    /// a BinaryOperationAndReassign instruction
+    func testVariableAnalyzer() {
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let v0 = b.loadInt(1337)
+        let v1 = b.loadFloat(13.37)
+        b.binaryOpAndReassign(v0, to: v1, with: .Add)
+        let v2 = b.loadString("Hello")
+        b.reassign(v1, to: v2)
+        let v3 = b.loadInt(1336)
+        let v4 = b.unary(.PreInc, v3)
+        b.unary(.PostInc, v4)
+
+        let program = b.finalize()
+
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        let v0 = 1337;
+        let v1 = 13.37;
+        v0 += v1;
+        v1 = "Hello";
+        let v3 = 1336;
+        let v4 = ++v3;
+        const v5 = v4++;
 
         """
 
@@ -615,7 +643,8 @@ extension LifterTests {
             ("testTryFinallyLifting", testTryFinallyLifting),
             ("testComputedMethodLifting", testComputedMethodLifting),
             ("testConditionalOperationLifting", testConditionalOperationLifting),
-            ("testAssignmentOperationLifting", testAssignmentOperationLifting),
+            ("testBinaryOperationReassignLifting", testBinaryOperationReassignLifting),
+            ("testVariableAnalyzer", testVariableAnalyzer),
         ]
     }
 }

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -91,6 +91,7 @@ extension ProgramBuilderTests {
         ("testSplicing2", testSplicing2),
         ("testSplicing3", testSplicing3),
         ("testTypeInstantiation", testTypeInstantiation),
+        ("testVariableReuse", testVariableReuse),
     ]
 }
 

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -24,6 +24,7 @@ extension AbstractInterpreterTests {
         ("testReassignments", testReassignments),
         ("testReturnTypeInference", testReturnTypeInference),
         ("testSuperBinding", testSuperBinding),
+        ("testBigintTypeTracking", testBigintTypeTracking),
     ]
 }
 

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -65,6 +65,7 @@ extension LifterTests {
         ("testTryFinallyLifting", testTryFinallyLifting),
         ("testComputedMethodLifting", testComputedMethodLifting),
         ("testConditionalOperationLifting", testConditionalOperationLifting),
+        ("testAssignmentOperationLifting", testAssignmentOperationLifting),
     ]
 }
 

--- a/Tests/FuzzilliTests/XCTestManifests.swift
+++ b/Tests/FuzzilliTests/XCTestManifests.swift
@@ -65,7 +65,8 @@ extension LifterTests {
         ("testTryFinallyLifting", testTryFinallyLifting),
         ("testComputedMethodLifting", testComputedMethodLifting),
         ("testConditionalOperationLifting", testConditionalOperationLifting),
-        ("testAssignmentOperationLifting", testAssignmentOperationLifting),
+        ("testBinaryOperationReassignLifting", testBinaryOperationReassignLifting),
+        ("testVariableAnalyzer", testVariableAnalyzer),
     ]
 }
 
@@ -88,6 +89,7 @@ extension ProgramBuilderTests {
         ("testSplicing1", testSplicing1),
         ("testSplicing2", testSplicing2),
         ("testSplicing3", testSplicing3),
+        ("testTypeInstantiation", testTypeInstantiation),
     ]
 }
 


### PR DESCRIPTION
This PR adds support for [assignment operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators).