### PR TITLE
add support for template literals

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -97,6 +97,20 @@ public let CodeGenerators: [CodeGenerator] = [
         b.createArray(with: initialValues, spreading: spreads)
     },
 
+    CodeGenerator("TemplateLiteralGenerator") { b in
+        var identifiers = [Variable]()
+        for _ in 1..<Int.random(in: 1...5) {
+            identifiers.append(b.randVar())
+        }
+
+        var literals = [String]()
+        for _ in 0...identifiers.count {
+            // For now we generate random strings
+            literals.append(b.genString())
+        }
+        b.createTemplateLiteral(with: literals, andIdentifiers: identifiers)
+    },
+
     CodeGenerator("BuiltinGenerator") { b in
         b.loadBuiltin(b.genBuiltinName())
     },

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -97,18 +97,18 @@ public let CodeGenerators: [CodeGenerator] = [
         b.createArray(with: initialValues, spreading: spreads)
     },
 
-    CodeGenerator("TemplateLiteralGenerator") { b in
-        var identifiers = [Variable]()
+    CodeGenerator("TemplateStringGenerator") { b in
+        var interpolatedValues = [Variable]()
         for _ in 1..<Int.random(in: 1...5) {
-            identifiers.append(b.randVar())
+            interpolatedValues.append(b.randVar())
         }
 
-        var literals = [String]()
-        for _ in 0...identifiers.count {
+        var parts = [String]()
+        for _ in 0...interpolatedValues.count {
             // For now we generate random strings
-            literals.append(b.genString())
+            parts.append(b.genString())
         }
-        b.createTemplateLiteral(with: literals, andIdentifiers: identifiers)
+        b.createTemplateString(from: parts, interpolating: interpolatedValues)
     },
 
     CodeGenerator("BuiltinGenerator") { b in

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1009,8 +1009,8 @@ public class ProgramBuilder {
     }
 
     @discardableResult
-    public func createTemplateLiteral(with literals: [String], andIdentifiers identifiers: [Variable]) -> Variable {
-        return perform(CreateTemplateLiteral(literals: literals), withInputs: identifiers).output
+    public func createTemplateString(from parts: [String], interpolating interpolatedValues: [Variable]) -> Variable {
+        return perform(CreateTemplateString(parts: parts), withInputs: interpolatedValues).output
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -999,6 +999,11 @@ public class ProgramBuilder {
     }
 
     @discardableResult
+    public func createTemplateLiteral(with literals: [String], andIdentifiers identifiers: [Variable]) -> Variable {
+        return perform(CreateTemplateLiteral(literals: literals), withInputs: identifiers).output
+    }
+
+    @discardableResult
     public func loadBuiltin(_ name: String) -> Variable {
         return perform(LoadBuiltin(builtinName: name)).output
     }

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -480,6 +480,16 @@ public class ProgramBuilder {
         if type.Is(.bigint) || type.Is(fuzzer.environment.bigIntType) {
             return loadBigInt(genInt())
         }
+        if type.Is(.function()) {
+            let signature = type.signature ?? FunctionSignature(withParameterCount: Int.random(in: 2...5), hasRestParam: probability(0.1)) { _ in
+                generateRecursive()
+                doReturn(value: randVar())
+            }
+            return definePlainFunction(withSignature: signature)
+        }
+        if type.Is(.regexp) || type.Is(fuzzer.environment.regExpType) {
+            return loadRegExp(genRegExp(), genRegExpFlags())
+        }
 
         assert(type.Is(.object()), "Unexpected type encountered \(type)")
 

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -481,11 +481,11 @@ public class ProgramBuilder {
             return loadBigInt(genInt())
         }
         if type.Is(.function()) {
-            let signature = type.signature ?? FunctionSignature(withParameterCount: Int.random(in: 2...5), hasRestParam: probability(0.1)) { _ in
+            let signature = type.signature ?? FunctionSignature(withParameterCount: Int.random(in: 2...5), hasRestParam: probability(0.1)) 
+            return definePlainFunction(withSignature: signature) { _ in
                 generateRecursive()
                 doReturn(value: randVar())
             }
-            return definePlainFunction(withSignature: signature)
         }
         if type.Is(.regexp) || type.Is(fuzzer.environment.regExpType) {
             return loadRegExp(genRegExp(), genRegExpFlags())

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -362,7 +362,7 @@ public struct AbstractInterpreter {
              is CreateArrayWithSpread:
             set(instr.output, environment.arrayType)
 
-        case is CreateTemplateLiteral:
+        case is CreateTemplateString:
             set(instr.output, environment.stringType)
 
         case let op as StoreProperty:

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -362,6 +362,9 @@ public struct AbstractInterpreter {
              is CreateArrayWithSpread:
             set(instr.output, environment.arrayType)
 
+        case is CreateTemplateLiteral:
+            set(instr.output, environment.stringType)
+
         case let op as StoreProperty:
             if environment.customMethodNames.contains(op.propertyName) {
                 set(instr.input(0), type(ofInput: 0).adding(method: op.propertyName))

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -290,8 +290,8 @@ extension Instruction: ProtobufConvertible {
                 $0.createArray = Fuzzilli_Protobuf_CreateArray()
             case let op as CreateArrayWithSpread:
                 $0.createArrayWithSpread = Fuzzilli_Protobuf_CreateArrayWithSpread.with { $0.spreads = op.spreads }
-            case let op as CreateTemplateLiteral:
-                $0.createTemplateLiteral = Fuzzilli_Protobuf_CreateTemplateLiteral.with { $0.literals = op.literals }
+            case let op as CreateTemplateString:
+                $0.createTemplateString = Fuzzilli_Protobuf_CreateTemplateString.with { $0.parts = op.parts }
             case let op as LoadBuiltin:
                 $0.loadBuiltin = Fuzzilli_Protobuf_LoadBuiltin.with { $0.builtinName = op.builtinName }
             case let op as LoadProperty:
@@ -527,8 +527,8 @@ extension Instruction: ProtobufConvertible {
             op = CreateObjectWithSpread(propertyNames: p.propertyNames, numSpreads: inouts.count - 1 - p.propertyNames.count)
         case .createArrayWithSpread(let p):
             op = CreateArrayWithSpread(numInitialValues: inouts.count - 1, spreads: p.spreads)
-        case .createTemplateLiteral(let p):
-            op = CreateTemplateLiteral(literals: p.literals)
+        case .createTemplateString(let p):
+            op = CreateTemplateString(parts: p.parts)
         case .loadBuiltin(let p):
             op = LoadBuiltin(builtinName: p.builtinName)
         case .loadProperty(let p):

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -290,6 +290,8 @@ extension Instruction: ProtobufConvertible {
                 $0.createArray = Fuzzilli_Protobuf_CreateArray()
             case let op as CreateArrayWithSpread:
                 $0.createArrayWithSpread = Fuzzilli_Protobuf_CreateArrayWithSpread.with { $0.spreads = op.spreads }
+            case let op as CreateTemplateLiteral:
+                $0.createTemplateLiteral = Fuzzilli_Protobuf_CreateTemplateLiteral.with { $0.literals = op.literals }
             case let op as LoadBuiltin:
                 $0.loadBuiltin = Fuzzilli_Protobuf_LoadBuiltin.with { $0.builtinName = op.builtinName }
             case let op as LoadProperty:
@@ -525,6 +527,8 @@ extension Instruction: ProtobufConvertible {
             op = CreateObjectWithSpread(propertyNames: p.propertyNames, numSpreads: inouts.count - 1 - p.propertyNames.count)
         case .createArrayWithSpread(let p):
             op = CreateArrayWithSpread(numInitialValues: inouts.count - 1, spreads: p.spreads)
+        case .createTemplateLiteral(let p):
+            op = CreateTemplateLiteral(literals: p.literals)
         case .loadBuiltin(let p):
             op = LoadBuiltin(builtinName: p.builtinName)
         case .loadProperty(let p):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -250,7 +250,7 @@ class CreateTemplateLiteral: Operation {
 
     init(literals: [String]) {
         self.literals = literals
-        super.init(numInputs: literals.count > 0 ? literals.count - 1 : 0, numOutputs: 1, attributes: [.isVarargs, .isLiteral])
+        super.init(numInputs: literals.count > 0 ? literals.count - 1 : 0, numOutputs: 1, attributes: [.isVarargs, .isPure])
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -240,6 +240,20 @@ class CreateArrayWithSpread: Operation {
     }
 }
 
+class CreateTemplateLiteral: Operation {
+    // Stores the string elements of the temaplate literal
+    let literals: [String]
+
+    var numIdentifiers: Int {
+        return numInputs
+    }
+
+    init(literals: [String]) {
+        self.literals = literals
+        super.init(numInputs: literals.count > 0 ? literals.count - 1 : 0, numOutputs: 1, attributes: [.isVarargs, .isLiteral])
+    }
+}
+
 class LoadBuiltin: Operation {
     let builtinName: String
     

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -240,17 +240,20 @@ class CreateArrayWithSpread: Operation {
     }
 }
 
-class CreateTemplateLiteral: Operation {
+class CreateTemplateString: Operation {
     // Stores the string elements of the temaplate literal
-    let literals: [String]
+    let parts: [String]
 
-    var numIdentifiers: Int {
+    var numInterpolatedValues: Int {
         return numInputs
     }
 
-    init(literals: [String]) {
-        self.literals = literals
-        super.init(numInputs: literals.count > 0 ? literals.count - 1 : 0, numOutputs: 1, attributes: [.isVarargs, .isPure])
+    // This operation isn't parametric since it will most likely mutate imported templates (which would mostly be valid JS snippets) and
+    // replace them with random strings and/or other template strings that may not be syntactically and/or semantically valid.
+    init(parts: [String]) {
+        self.parts = parts
+        assert(parts.count > 0)
+        super.init(numInputs: parts.count - 1, numOutputs: 1, attributes: [.isVarargs])
     }
 }
 

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -82,6 +82,18 @@ public class FuzzILLifter: Lifter {
             }
             w.emit("\(instr.output) <- CreateArrayWithSpread [\(elems.joined(separator: ", "))]")
 
+        case let op as CreateTemplateLiteral:
+            var literals = [String]()
+            if op.literals.count > 0 {
+                for index in  0..<op.numIdentifiers {
+                    literals.append("'\(op.literals[index])', \(input(index))")
+                }
+                literals.append("'\(op.literals.last!)'")
+                w.emit("\(instr.output) <- CreateTemplateLiteral [\(literals.joined(separator: ", "))]")
+            } else {
+                w.emit("\(instr.output) <- CreateTemplateLiteral []")
+            }
+
         case let op as LoadBuiltin:
             w.emit("\(instr.output) <- LoadBuiltin '\(op.builtinName)'")
 

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -82,17 +82,10 @@ public class FuzzILLifter: Lifter {
             }
             w.emit("\(instr.output) <- CreateArrayWithSpread [\(elems.joined(separator: ", "))]")
 
-        case let op as CreateTemplateLiteral:
-            var literals = [String]()
-            if op.literals.count > 0 {
-                for index in  0..<op.numIdentifiers {
-                    literals.append("'\(op.literals[index])', \(input(index))")
-                }
-                literals.append("'\(op.literals.last!)'")
-                w.emit("\(instr.output) <- CreateTemplateLiteral [\(literals.joined(separator: ", "))]")
-            } else {
-                w.emit("\(instr.output) <- CreateTemplateLiteral []")
-            }
+        case let op as CreateTemplateString:
+            let parts = op.parts.map({ "'\($0)'" }).joined(separator: ", ")
+            let values = instr.inputs.map({ $0.identifier }).joined(separator: ", ")
+            w.emit("\(instr.output) <- CreateTemplateString [\(parts)], [\(values)]")
 
         case let op as LoadBuiltin:
             w.emit("\(instr.output) <- LoadBuiltin '\(op.builtinName)'")

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -213,6 +213,18 @@ public class JavaScriptLifter: Lifter {
                 }
                 output = ArrayLiteral.new("[" + elems.joined(separator: ",") + "]")
 
+            case let op as CreateTemplateLiteral:
+                var literals = [String]()
+                if op.literals.count > 0 {
+                    for index in  0..<op.numIdentifiers {
+                        literals.append(op.literals[index] + "${\(input(index))}")
+                    }
+                    literals.append(op.literals.last!)
+                    output = Literal.new("`" + literals.joined() + "`")
+                } else {
+                    output = Literal.new("``")
+                }
+
             case let op as LoadBuiltin:
                 output = Identifier.new(op.builtinName)
 

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -213,17 +213,14 @@ public class JavaScriptLifter: Lifter {
                 }
                 output = ArrayLiteral.new("[" + elems.joined(separator: ",") + "]")
 
-            case let op as CreateTemplateLiteral:
-                var literals = [String]()
-                if op.literals.count > 0 {
-                    for index in  0..<op.numIdentifiers {
-                        literals.append(op.literals[index] + "${\(input(index))}")
-                    }
-                    literals.append(op.literals.last!)
-                    output = Literal.new("`" + literals.joined() + "`")
-                } else {
-                    output = Literal.new("``")
+            case let op as CreateTemplateString:
+                assert(!op.parts.isEmpty)
+                assert(op.parts.count == instr.numInputs + 1)
+                var parts = [op.parts[0]]
+                for i in 1..<op.parts.count {
+                    parts.append("${\(input(i - 1))}\(op.parts[i])")
                 }
+                output = Literal.new("`" + parts.joined() + "`")
 
             case let op as LoadBuiltin:
                 output = Identifier.new(op.builtinName)

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -366,6 +366,18 @@ public struct Fuzzilli_Protobuf_CreateArray {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_CreateTemplateLiteral {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var literals: [String] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_CreateObjectWithSpread {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1688,6 +1700,38 @@ extension Fuzzilli_Protobuf_CreateArray: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_CreateArray, rhs: Fuzzilli_Protobuf_CreateArray) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_CreateTemplateLiteral: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateTemplateLiteral"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "literals"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.literals) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.literals.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.literals, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_CreateTemplateLiteral, rhs: Fuzzilli_Protobuf_CreateTemplateLiteral) -> Bool {
+    if lhs.literals != rhs.literals {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -366,12 +366,12 @@ public struct Fuzzilli_Protobuf_CreateArray {
   public init() {}
 }
 
-public struct Fuzzilli_Protobuf_CreateTemplateLiteral {
+public struct Fuzzilli_Protobuf_CreateTemplateString {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var literals: [String] = []
+  public var parts: [String] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1705,10 +1705,10 @@ extension Fuzzilli_Protobuf_CreateArray: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Fuzzilli_Protobuf_CreateTemplateLiteral: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".CreateTemplateLiteral"
+extension Fuzzilli_Protobuf_CreateTemplateString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateTemplateString"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "literals"),
+    1: .same(proto: "parts"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1717,21 +1717,21 @@ extension Fuzzilli_Protobuf_CreateTemplateLiteral: SwiftProtobuf.Message, SwiftP
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedStringField(value: &self.literals) }()
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.parts) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.literals.isEmpty {
-      try visitor.visitRepeatedStringField(value: self.literals, fieldNumber: 1)
+    if !self.parts.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.parts, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Fuzzilli_Protobuf_CreateTemplateLiteral, rhs: Fuzzilli_Protobuf_CreateTemplateLiteral) -> Bool {
-    if lhs.literals != rhs.literals {return false}
+  public static func ==(lhs: Fuzzilli_Protobuf_CreateTemplateString, rhs: Fuzzilli_Protobuf_CreateTemplateString) -> Bool {
+    if lhs.parts != rhs.parts {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -55,6 +55,10 @@ message CreateObject {
 message CreateArray {
 }
 
+message CreateTemplateLiteral {
+    repeated string literals = 1;
+}
+
 message CreateObjectWithSpread {
     repeated string propertyNames = 1;
 }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -55,8 +55,8 @@ message CreateObject {
 message CreateArray {
 }
 
-message CreateTemplateLiteral {
-    repeated string literals = 1;
+message CreateTemplateString {
+    repeated string parts = 1;
 }
 
 message CreateObjectWithSpread {

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -1534,7 +1534,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     77: .same(proto: "loadRegExp"),
     11: .same(proto: "createObject"),
     12: .same(proto: "createArray"),
-    100: .same(proto: "createTemplateLiteral"),
+    102: .same(proto: "createTemplateLiteral"),
     13: .same(proto: "createObjectWithSpread"),
     14: .same(proto: "createArrayWithSpread"),
     15: .same(proto: "loadBuiltin"),
@@ -2490,6 +2490,15 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {self.operation = .endSwitch(v)}
       }()
+      case 102: try {
+        var v: Fuzzilli_Protobuf_CreateTemplateLiteral?
+        if let current = self.operation {
+          try decoder.handleConflictingOneOf()
+          if case .createTemplateLiteral(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.operation = .createTemplateLiteral(v)}
+      }()
       default: break
       }
     }
@@ -2886,6 +2895,10 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .endSwitch?: try {
       guard case .endSwitch(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 101)
+    }()
+    case .createTemplateLiteral?: try {
+      guard case .createTemplateLiteral(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -225,12 +225,12 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .createArray(newValue)}
   }
 
-  public var createTemplateLiteral: Fuzzilli_Protobuf_CreateTemplateLiteral {
+  public var createTemplateString: Fuzzilli_Protobuf_CreateTemplateString {
     get {
-      if case .createTemplateLiteral(let v)? = operation {return v}
-      return Fuzzilli_Protobuf_CreateTemplateLiteral()
+      if case .createTemplateString(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_CreateTemplateString()
     }
-    set {operation = .createTemplateLiteral(newValue)}
+    set {operation = .createTemplateString(newValue)}
   }
 
   public var createObjectWithSpread: Fuzzilli_Protobuf_CreateObjectWithSpread {
@@ -928,7 +928,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case loadRegExp(Fuzzilli_Protobuf_LoadRegExp)
     case createObject(Fuzzilli_Protobuf_CreateObject)
     case createArray(Fuzzilli_Protobuf_CreateArray)
-    case createTemplateLiteral(Fuzzilli_Protobuf_CreateTemplateLiteral)
+    case createTemplateString(Fuzzilli_Protobuf_CreateTemplateString)
     case createObjectWithSpread(Fuzzilli_Protobuf_CreateObjectWithSpread)
     case createArrayWithSpread(Fuzzilli_Protobuf_CreateArrayWithSpread)
     case loadBuiltin(Fuzzilli_Protobuf_LoadBuiltin)
@@ -1065,8 +1065,8 @@ public struct Fuzzilli_Protobuf_Instruction {
         guard case .createArray(let l) = lhs, case .createArray(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
-      case (.createTemplateLiteral, .createTemplateLiteral): return {
-        guard case .createTemplateLiteral(let l) = lhs, case .createTemplateLiteral(let r) = rhs else { preconditionFailure() }
+      case (.createTemplateString, .createTemplateString): return {
+        guard case .createTemplateString(let l) = lhs, case .createTemplateString(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.createObjectWithSpread, .createObjectWithSpread): return {
@@ -1534,7 +1534,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     77: .same(proto: "loadRegExp"),
     11: .same(proto: "createObject"),
     12: .same(proto: "createArray"),
-    102: .same(proto: "createTemplateLiteral"),
+    102: .same(proto: "createTemplateString"),
     13: .same(proto: "createObjectWithSpread"),
     14: .same(proto: "createArrayWithSpread"),
     15: .same(proto: "loadBuiltin"),
@@ -2491,13 +2491,13 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
         if let v = v {self.operation = .endSwitch(v)}
       }()
       case 102: try {
-        var v: Fuzzilli_Protobuf_CreateTemplateLiteral?
+        var v: Fuzzilli_Protobuf_CreateTemplateString?
         if let current = self.operation {
           try decoder.handleConflictingOneOf()
-          if case .createTemplateLiteral(let m) = current {v = m}
+          if case .createTemplateString(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.operation = .createTemplateLiteral(v)}
+        if let v = v {self.operation = .createTemplateString(v)}
       }()
       default: break
       }
@@ -2896,8 +2896,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
       guard case .endSwitch(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 101)
     }()
-    case .createTemplateLiteral?: try {
-      guard case .createTemplateLiteral(let v)? = self.operation else { preconditionFailure() }
+    case .createTemplateString?: try {
+      guard case .createTemplateString(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
     }()
     case nil: break

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -225,6 +225,14 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .createArray(newValue)}
   }
 
+  public var createTemplateLiteral: Fuzzilli_Protobuf_CreateTemplateLiteral {
+    get {
+      if case .createTemplateLiteral(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_CreateTemplateLiteral()
+    }
+    set {operation = .createTemplateLiteral(newValue)}
+  }
+
   public var createObjectWithSpread: Fuzzilli_Protobuf_CreateObjectWithSpread {
     get {
       if case .createObjectWithSpread(let v)? = operation {return v}
@@ -920,6 +928,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case loadRegExp(Fuzzilli_Protobuf_LoadRegExp)
     case createObject(Fuzzilli_Protobuf_CreateObject)
     case createArray(Fuzzilli_Protobuf_CreateArray)
+    case createTemplateLiteral(Fuzzilli_Protobuf_CreateTemplateLiteral)
     case createObjectWithSpread(Fuzzilli_Protobuf_CreateObjectWithSpread)
     case createArrayWithSpread(Fuzzilli_Protobuf_CreateArrayWithSpread)
     case loadBuiltin(Fuzzilli_Protobuf_LoadBuiltin)
@@ -1054,6 +1063,10 @@ public struct Fuzzilli_Protobuf_Instruction {
       }()
       case (.createArray, .createArray): return {
         guard case .createArray(let l) = lhs, case .createArray(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.createTemplateLiteral, .createTemplateLiteral): return {
+        guard case .createTemplateLiteral(let l) = lhs, case .createTemplateLiteral(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.createObjectWithSpread, .createObjectWithSpread): return {
@@ -1521,6 +1534,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     77: .same(proto: "loadRegExp"),
     11: .same(proto: "createObject"),
     12: .same(proto: "createArray"),
+    100: .same(proto: "createTemplateLiteral"),
     13: .same(proto: "createObjectWithSpread"),
     14: .same(proto: "createArrayWithSpread"),
     15: .same(proto: "loadBuiltin"),

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -36,7 +36,7 @@ message Instruction {
         LoadRegExp loadRegExp = 77;
         CreateObject createObject = 11;
         CreateArray createArray = 12;
-        CreateTemplateLiteral createTemplateLiteral = 102;
+        CreateTemplateString createTemplateString = 102;
         CreateObjectWithSpread createObjectWithSpread = 13;
         CreateArrayWithSpread createArrayWithSpread = 14;
         LoadBuiltin loadBuiltin = 15;

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -36,7 +36,7 @@ message Instruction {
         LoadRegExp loadRegExp = 77;
         CreateObject createObject = 11;
         CreateArray createArray = 12;
-        CreateTemplateLiteral createTemplateLiteral = 100;
+        CreateTemplateLiteral createTemplateLiteral = 102;
         CreateObjectWithSpread createObjectWithSpread = 13;
         CreateArrayWithSpread createArrayWithSpread = 14;
         LoadBuiltin loadBuiltin = 15;

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -36,6 +36,7 @@ message Instruction {
         LoadRegExp loadRegExp = 77;
         CreateObject createObject = 11;
         CreateArray createArray = 12;
+        CreateTemplateLiteral createTemplateLiteral = 100;
         CreateObjectWithSpread createObjectWithSpread = 13;
         CreateArrayWithSpread createArrayWithSpread = 14;
         LoadBuiltin loadBuiltin = 15;

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -30,6 +30,7 @@ let codeGeneratorWeights = [
     "ArrayGenerator":                       10,
     "ObjectWithSpreadGenerator":            5,
     "ArrayWithSpreadGenerator":             5,
+    "TemplateLiteralGenerator":             1,
     "PlainFunctionGenerator":               15,
     "StrictFunctionGenerator":              1,
     "ArrowFunctionGenerator":               3,

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -30,7 +30,7 @@ let codeGeneratorWeights = [
     "ArrayGenerator":                       10,
     "ObjectWithSpreadGenerator":            5,
     "ArrayWithSpreadGenerator":             5,
-    "TemplateLiteralGenerator":             1,
+    "TemplateStringGenerator":              1,
     "PlainFunctionGenerator":               15,
     "StrictFunctionGenerator":              1,
     "ArrowFunctionGenerator":               3,

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -679,12 +679,12 @@ class LifterTests: XCTestCase {
         let b = fuzzer.makeBuilder()
 
         let v0 = b.loadInt(1337)
-        let _ = b.createTemplateLiteral(with: [], andIdentifiers: [])
-        let v2 = b.createTemplateLiteral(with: ["Hello", "World"], andIdentifiers: [v0])
+        let _ = b.createTemplateString(from: [""], interpolating: [])
+        let v2 = b.createTemplateString(from: ["Hello", "World"], interpolating: [v0])
         let v3 = b.createObject(with: ["foo": v0])
         let v4 = b.loadProperty("foo", of: v3)
-        let _ = b.createTemplateLiteral(with: ["bar", "baz"], andIdentifiers: [v4])
-        let _ = b.createTemplateLiteral(with: ["test", "inserted", "template"], andIdentifiers: [v4, v2] )
+        let _ = b.createTemplateString(from: ["bar", "baz"], interpolating: [v4])
+        let _ = b.createTemplateString(from: ["test", "inserted", "template"], interpolating: [v4, v2] )
 
         let program = b.finalize()
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -670,6 +670,33 @@ class LifterTests: XCTestCase {
         const v5 = v4++;
 
         """
+        
+        XCTAssertEqual(lifted_program,expected_program)
+    }
+
+    func testCreateTemplateLifting(){
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let v0 = b.loadInt(1337)
+        let _ = b.createTemplateLiteral(with: [], andIdentifiers: [])
+        let v2 = b.createTemplateLiteral(with: ["Hello", "World"], andIdentifiers: [v0])
+        let v3 = b.createObject(with: ["foo": v0])
+        let v4 = b.loadProperty("foo", of: v3)
+        let _ = b.createTemplateLiteral(with: ["bar", "baz"], andIdentifiers: [v4])
+        let _ = b.createTemplateLiteral(with: ["test", "inserted", "template"], andIdentifiers: [v4, v2] )
+
+        let program = b.finalize()
+
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        const v1 = ``;
+        const v3 = {foo:1337};
+        const v4 = v3.foo;
+        const v5 = `bar${v4}baz`;
+        const v6 = `test${v4}inserted${`Hello${1337}World`}template`;
+
+        """
 
         XCTAssertEqual(lifted_program,expected_program)
     }
@@ -695,6 +722,7 @@ extension LifterTests {
             ("testBinaryOperationReassignLifting", testBinaryOperationReassignLifting),
             ("testVariableAnalyzer", testVariableAnalyzer),
             ("testSwitchStatementLifting", testSwitchStatementLifting),
+            ("testCreateTemplateLifting", testCreateTemplateLifting),
         ]
     }
 }


### PR DESCRIPTION
This PR implements support for generating [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)

Also see discussion at #202 

This PR also includes patches discussed in #209 and #210