### PR TITLE
Compiler type constant and spelling fix

### DIFF
--- a/Compiler/src/ProgramBuilder.ml
+++ b/Compiler/src/ProgramBuilder.ml
@@ -60,8 +60,8 @@ type unary_op = Not
     | PostDec
 
 (* TODO: Expand these into full constructors, similar to what is in TypeSystem.swift *)
-let unknown_type_int = Int32.sub (Int32.shift_left 1l 12) 1l
-let anything_type_int = Int32.shift_left 1l 8
+let unknown_type_int = Int32.shift_left 1l 8
+let anything_type_int = Int32.sub (Int32.shift_left 1l 12) 1l
 let nothing_type_int = 0l
 
 let translate_compare_op compare_op =

--- a/Compiler/src/translate.ml
+++ b/Compiler/src/translate.ml
@@ -138,7 +138,7 @@ and proc_exp_id (id_val: ('M, 'T) Flow_ast.Identifier.t) builder =
                 let (result_var, inst) = build_load_builtin "placeholder" builder in
                 (result_var, [inst])
             else
-                raise (Invalid_argument ("Unhandled buitlin " ^ name))
+                raise (Invalid_argument ("Unhandled builtin " ^ name))
 
 and proc_exp_bin_op (bin_op: ('M, 'T) Flow_ast.Expression.Binary.t) builder =
     let (lvar, linsts) = proc_expression bin_op.left builder in


### PR DESCRIPTION
Fixes a type issue in the compiler, where the constants for anything and unknown were backwards. 
I believe this should close #199, as I triggered it consistently before, but have not seen it recently.

Also fixes a spelling error