### PR TITLE
Yield Operation in FuzzIL should have an Output

### DIFF
--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1131,8 +1131,9 @@ public class ProgramBuilder {
         perform(Return(), withInputs: [value])
     }
 
-    public func yield(value: Variable) {
-        perform(Yield(), withInputs: [value])
+    @discardableResult
+    public func yield(value: Variable) -> Variable {
+        return perform(Yield(), withInputs: [value]).output
     }
 
     public func yieldEach(value: Variable) {

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -486,6 +486,9 @@ public struct AbstractInterpreter {
             // TODO if input type is known, set to input type and possibly unwrap the Promise
             set(instr.output, .unknown)
 
+        case is Yield:
+            set(instr.output, .unknown)
+
         case let op as BeginAnyFunctionDefinition:
             processParameterDeclarations(instr.innerOutputs, signature: op.signature)
 

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -416,7 +416,7 @@ class Return: Operation {
 // A yield expression in JavaScript
 class Yield: Operation {
     init() {
-        super.init(numInputs: 1, numOutputs: 0, attributes: [])
+        super.init(numInputs: 1, numOutputs: 1, attributes: [])
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -31,7 +31,8 @@ extension Operation {
             return true
         case is StoreProperty,
              is StoreElement,
-             is StoreComputedProperty:
+             is StoreComputedProperty,
+             is Yield:
             return inputIdx == 0
         default:
             return false

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -139,7 +139,7 @@ public class FuzzILLifter: Lifter {
             w.emit("Return \(input(0))")
 
         case is Yield:
-            w.emit("Yield \(input(0))")
+            w.emit("\(instr.output) <- Yield \(input(0))")
 
         case is YieldEach:
             w.emit("YieldEach \(input(0))")

--- a/Sources/Fuzzilli/Lifting/JSExpressions.swift
+++ b/Sources/Fuzzilli/Lifting/JSExpressions.swift
@@ -28,6 +28,7 @@ public let BinaryExpression     = ExpressionType(precedence: 14, associativity: 
 public let TernaryExpression    = ExpressionType(precedence: 4,  associativity: .none,  inline: .singleUseOnly)
 public let AssignmentExpression = ExpressionType(precedence: 3,                         inline: .never)
 public let ListExpression       = ExpressionType(precedence: 1,  associativity: .left,  inline: .never)
+public let YieldExpression      = ExpressionType(precedence: 2,  associativity: .right, inline: .never)
 
 public struct InlineOnlyLiterals: InliningPolicy {
     public init() {}

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -311,7 +311,7 @@ public class JavaScriptLifter: Lifter {
                 w.emit("return \(input(0));")
 
             case is Yield:
-                w.emit("yield \(input(0));")
+                output = YieldExpression.new() <> "yield " <> input(0)
 
             case is YieldEach:
                 w.emit("yield* \(input(0));")


### PR DESCRIPTION
Yield Operation in FuzzIL should have 1 output. 
For example:
```
function* generator(){
  let x=20;
  x= yield 100;
  yield x;
}
var gen = generator();
gen.next().value
gen.next(1).value; 
```
then the function can be compiled to
```
v0 <- LoadInteger 20;
v1 <- LoadInteger 100;
v2 <- Yield v1;
Reassign v0, v2;
v3 <- Yield v0;
```

Also,  yield gives its input and control flow outside the generator function, so maybe Yield Operator should have 'may mutate' property?
For example:
```
function* generator() {
  let a={ 1: 2};
  yield a;
  yield a;
  yield a;
  yield a;

}
var gen=generator();
console.log(gen.next());
let x=gen.next().value;
x[1]=3;
console.log(gen.next());
```

The variable 'a' inside generator function is mutated after yield.