### PR TITLE
Delete operations have one boolean output

### DIFF
--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1026,8 +1026,9 @@ public class ProgramBuilder {
         perform(StoreProperty(propertyName: name), withInputs: [object, value])
     }
 
-    public func deleteProperty(_ name: String, of object: Variable) {
-        perform(DeleteProperty(propertyName: name), withInputs: [object])
+    @discardableResult
+    public func deleteProperty(_ name: String, of object: Variable) -> Variable {
+        perform(DeleteProperty(propertyName: name), withInputs: [object]).output
     }
 
     @discardableResult
@@ -1039,8 +1040,9 @@ public class ProgramBuilder {
         perform(StoreElement(index: index), withInputs: [array, value])
     }
 
-    public func deleteElement(_ index: Int64, of array: Variable) {
-        perform(DeleteElement(index: index), withInputs: [array])
+    @discardableResult
+    public func deleteElement(_ index: Int64, of array: Variable) -> Variable {
+        perform(DeleteElement(index: index), withInputs: [array]).output
     }
 
     @discardableResult
@@ -1052,8 +1054,9 @@ public class ProgramBuilder {
         perform(StoreComputedProperty(), withInputs: [object, name, value])
     }
 
-    public func deleteComputedProperty(_ name: Variable, of object: Variable) {
-        perform(DeleteComputedProperty(), withInputs: [object, name])
+    @discardableResult
+    public func deleteComputedProperty(_ name: Variable, of object: Variable) -> Variable {
+        perform(DeleteComputedProperty(), withInputs: [object, name]).output
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -374,6 +374,12 @@ public struct AbstractInterpreter {
 
         case let op as DeleteProperty:
             set(instr.input(0), type(ofInput: 0).removing(property: op.propertyName))
+            set(instr.output, .boolean)
+
+        // TODO: An additional analyzer is required to determine the runtime value of the input variable
+        case is DeleteComputedProperty,
+             is DeleteElement:
+            set(instr.output, .boolean)
 
         case let op as LoadProperty:
             set(instr.output, inferPropertyType(of: op.propertyName, on: instr.input(0)))

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -289,7 +289,7 @@ class DeleteProperty: Operation {
     
     init(propertyName: String) {
         self.propertyName = propertyName
-        super.init(numInputs: 1, numOutputs: 0, attributes: [.isParametric])
+        super.init(numInputs: 1, numOutputs: 1, attributes: [.isParametric])
     }
 }
 
@@ -316,7 +316,7 @@ class DeleteElement: Operation {
     
     init(index: Int64) {
         self.index = index
-        super.init(numInputs: 1, numOutputs: 0, attributes: [.isParametric])
+        super.init(numInputs: 1, numOutputs: 1, attributes: [.isParametric])
     }
 }
 
@@ -334,7 +334,7 @@ class StoreComputedProperty: Operation {
 
 class DeleteComputedProperty: Operation {
     init() {
-        super.init(numInputs: 2, numOutputs: 0)
+        super.init(numInputs: 2, numOutputs: 1)
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -32,7 +32,10 @@ extension Operation {
         case is StoreProperty,
              is StoreElement,
              is StoreComputedProperty,
-             is Yield:
+             is Yield,
+             is DeleteProperty,
+             is DeleteComputedProperty,
+             is DeleteElement:
             return inputIdx == 0
         default:
             return false

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -97,7 +97,7 @@ public class FuzzILLifter: Lifter {
             w.emit("StoreProperty \(input(0)), '\(op.propertyName)', \(input(1))")
 
         case let op as DeleteProperty:
-            w.emit("DeleteProperty \(input(0)), '\(op.propertyName)'")
+            w.emit("\(instr.output) <- DeleteProperty \(input(0)), '\(op.propertyName)'")
 
         case let op as LoadElement:
             w.emit("\(instr.output) <- LoadElement \(input(0)), '\(op.index)'")
@@ -106,7 +106,7 @@ public class FuzzILLifter: Lifter {
             w.emit("StoreElement \(input(0)), '\(op.index)', \(input(1))")
 
         case let op as DeleteElement:
-            w.emit("DeleteElement \(input(0)), '\(op.index)'")
+            w.emit("\(instr.output) <- DeleteElement \(input(0)), '\(op.index)'")
 
         case is LoadComputedProperty:
             w.emit("\(instr.output) <- LoadComputedProperty \(input(0)), \(input(1))")
@@ -115,7 +115,7 @@ public class FuzzILLifter: Lifter {
             w.emit("StoreComputedProperty \(input(0)), \(input(1)), \(input(2))")
 
         case is DeleteComputedProperty:
-            w.emit("DeleteComputedProperty \(input(0)), \(input(1))")
+            w.emit("\(instr.output) <- DeleteComputedProperty \(input(0)), \(input(1))")
 
         case is TypeOf:
             w.emit("\(instr.output) <- TypeOf \(input(0))")

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -235,8 +235,7 @@ public class JavaScriptLifter: Lifter {
 
             case let op as DeleteProperty:
                 let target = MemberExpression.new() <> input(0) <> "." <> op.propertyName
-                let expr = UnaryExpression.new() <> "delete " <> target
-                w.emit(expr)
+                output = UnaryExpression.new() <> "delete " <> target
 
             case let op as LoadElement:
                 output = MemberExpression.new() <> input(0) <> "[" <> op.index <> "]"
@@ -248,8 +247,7 @@ public class JavaScriptLifter: Lifter {
 
             case let op as DeleteElement:
                 let target = MemberExpression.new() <> input(0) <> "[" <> op.index <> "]"
-                let expr = UnaryExpression.new() <> "delete " <> target
-                w.emit(expr)
+                output = UnaryExpression.new() <> "delete " <> target
 
             case is LoadComputedProperty:
                 output = MemberExpression.new() <> input(0) <> "[" <> input(1).text <> "]"
@@ -261,8 +259,7 @@ public class JavaScriptLifter: Lifter {
 
             case is DeleteComputedProperty:
                 let target = MemberExpression.new() <> input(0) <> "[" <> input(1).text <> "]"
-                let expr = UnaryExpression.new() <> "delete " <> target
-                w.emit(expr)
+                output = UnaryExpression.new() <> "delete " <> target
 
             case is TypeOf:
                 output = UnaryExpression.new() <> "typeof " <> input(0)

--- a/Tests/FuzzilliTests/InterpreterTest.swift
+++ b/Tests/FuzzilliTests/InterpreterTest.swift
@@ -50,7 +50,7 @@ class AbstractInterpreterTests: XCTestCase {
         b.storeProperty(intVar, as: "baz", on: obj)
         XCTAssertEqual(b.type(of: obj), .object(withProperties: ["foo", "bar", "baz"]))
 
-        b.deleteProperty("foo", of: obj)
+        let _ = b.deleteProperty("foo", of: obj)
         XCTAssertEqual(b.type(of: obj), .object(withProperties: ["bar", "baz"]))
 
         let method = b.definePlainFunction(withSignature: [] => .object()) { params in }

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -700,6 +700,38 @@ class LifterTests: XCTestCase {
 
         XCTAssertEqual(lifted_program,expected_program)
     }
+
+    func testDeleteOpsLifting(){
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let v0 = b.loadInt(1337)
+        let v1 = b.loadString("bar")
+        let v2 = b.loadFloat(13.37)
+        var initialProperties = [String: Variable]()
+        initialProperties["foo"] = v0
+        initialProperties["bar"] = v2
+        let v3 = b.createObject(with: initialProperties)
+        let _ = b.deleteProperty("foo", of: v3)
+        let _ = b.deleteComputedProperty(v1, of: v3)
+
+        let v10 = b.createArray(with: [b.loadInt(301), b.loadInt(4), b.loadInt(68), b.loadInt(22)])
+        let _ = b.deleteElement(3, of: v10)
+
+        let program = b.finalize()
+
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        const v3 = {bar:13.37,foo:1337};
+        const v4 = delete v3.foo;
+        const v5 = delete v3["bar"];
+        const v10 = [301,4,68,22];
+        const v11 = delete v10[3];
+        
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
 }
 
 extension LifterTests {
@@ -723,6 +755,7 @@ extension LifterTests {
             ("testVariableAnalyzer", testVariableAnalyzer),
             ("testSwitchStatementLifting", testSwitchStatementLifting),
             ("testCreateTemplateLifting", testCreateTemplateLifting),
+            ("testDeleteOpsLifting", testDeleteOpsLifting),
         ]
     }
 }


### PR DESCRIPTION
[Several](https://github.com/WebKit/WebKit/blob/main/JSTests/stress/delete-property-check-structure-transition.js) [jsc](https://github.com/WebKit/WebKit/blob/main/JSTests/stress/multi-del-by-offset-doesnt-always-def.js) [testcases](https://github.com/WebKit/WebKit/blob/main/JSTests/stress/array-toString-non-callable-join.js) use the output from delete operations and this PR enables this capability in FuzzIL