### PR TITLE
Simplify splicing

### DIFF
--- a/Docs/HowFuzzilliWorks.md
+++ b/Docs/HowFuzzilliWorks.md
@@ -264,7 +264,7 @@ CodeGenerator("FunctionCallGenerator") { b in
 }
 ```
 
-A final thing to note is that type information is only used for code generation and splicing (to find compatible variables in the existing code, through which the dataflow of the spliced code can be connected with the host program). "Pure" mutations (e.g. input and operation mutators) do not make use of type information to not risk restricting the fuzzer too much.
+It is important to note that, for mutation-based fuzzing, the AbstractInterpreter and the type system should be seen as optimizations, not essential features, and so the fuzzer must still be able to function without type information. In addition, while the use of type information for mutations can improve the performance of the fuzzer (less trivially incorrect samples are produced), too much reliance on it might restrict the fuzzer and thus affect the performance negatively (less diverse samples are produced). An example of this is the InputMutator, which can optionally be type aware, in which case it will attempt to find "compatible" replacement variables. In order to not restrict the fuzzer too much, Fuzzilli's MutationEngine is currently configured to use a non-type-aware InputMutator twice as often as a type-aware InputMutator.
 
 ### Type System
 Implementation: [TypeSystem.swift](https://github.com/googleprojectzero/fuzzilli/blob/master/Sources/Fuzzilli/FuzzIL/TypeSystem.swift)

--- a/Sources/Fuzzilli/Mutators/InputMutator.swift
+++ b/Sources/Fuzzilli/Mutators/InputMutator.swift
@@ -14,23 +14,49 @@
 
 /// A mutator that changes the input variables of instructions in a program.
 public class InputMutator: BaseInstructionMutator {
-    public init() {
-        super.init(maxSimultaneousMutations: defaultMaxSimultaneousMutations)
+    /// Whether this instance is type aware or not.
+    /// A type aware InputMutator will attempt to find "compatible" replacement
+    /// variables, which have roughly the same type as the replaced variable.
+    public let isTypeAware: Bool
+
+    /// The name of this mutator.
+    public override var name: String {
+        return isTypeAware ? "InputMutator (type aware)" : "InputMutator"
     }
-    
+
+    public init(isTypeAware: Bool) {
+        self.isTypeAware = isTypeAware
+        var maxSimultaneousMutations = defaultMaxSimultaneousMutations
+        // A type aware instance can be more aggressive. Based on simple experiments and
+        // the mutator correctness rates, it can very roughly be twice as aggressive.
+        if isTypeAware {
+            maxSimultaneousMutations *= 2
+        }
+        super.init(maxSimultaneousMutations: maxSimultaneousMutations)
+    }
+
     public override func canMutate(_ instr: Instruction) -> Bool {
         return instr.numInputs > 0
     }
     
     public override func mutate(_ instr: Instruction, _ b: ProgramBuilder) {
         var inouts = b.adopt(instr.inouts)
-        
+
         // Replace one input
         let selectedInput = Int.random(in: 0..<instr.numInputs)
-        b.trace("Mutating input \(selectedInput)")
-        // Inputs to block end instructions must be taken from the outer scope since the scope closed by the instruction is currently still active.
-        inouts[selectedInput] = instr.isBlockEnd ? b.randVarFromOuterScope() : b.randVar()
-                
+        // Inputs to block end instructions must be taken from the outer scope since the scope
+        // closed by the instruction is currently still active.
+        let replacement: Variable
+        if (isTypeAware) {
+            let type = b.type(of: inouts[selectedInput]).generalize()
+            // We are guaranteed to find at least the current input.
+            replacement = b.randVar(ofType: type, excludeInnermostScope: instr.isBlockEnd)!
+        } else {
+            replacement = b.randVar(excludeInnermostScope: instr.isBlockEnd)
+        }
+        b.trace("Replacing input \(selectedInput) (\(inouts[selectedInput])) with \(replacement)")
+        inouts[selectedInput] = replacement
+
         b.append(Instruction(instr.op, inouts: inouts))
     }
 }

--- a/Sources/Fuzzilli/Util/MockFuzzer.swift
+++ b/Sources/Fuzzilli/Util/MockFuzzer.swift
@@ -163,11 +163,11 @@ public func makeMockFuzzer(engine maybeEngine: FuzzEngine? = nil, runner maybeRu
 
     // the mutators to use for this fuzzing engine.
     let mutators = WeightedList<Mutator>([
-        (CodeGenMutator(),   1),
-        (OperationMutator(), 1),
-        (InputMutator(),     1),
-        (CombineMutator(),   1),
-        (JITStressMutator(), 1),
+        (CodeGenMutator(),                  1),
+        (OperationMutator(),                1),
+        (InputMutator(isTypeAware: false),  1),
+        (CombineMutator(),                  1),
+        (JITStressMutator(),                1),
     ])
 
     let engine = maybeEngine ?? MutationEngine(numConsecutiveMutations: 5)

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -365,11 +365,12 @@ func makeFuzzer(for profile: Profile, with configuration: Configuration) -> Fuzz
 
     /// The mutation fuzzer responsible for mutating programs from the corpus and evaluating the outcome.
     let mutators = WeightedList([
-        (CodeGenMutator(),   3),
-        (InputMutator(),     2),
-        (OperationMutator(), 1),
-        (CombineMutator(),   1),
-        (JITStressMutator(), 1),
+        (CodeGenMutator(),                  3),
+        (InputMutator(isTypeAware: false),  2),
+        (InputMutator(isTypeAware: true),   1),
+        (OperationMutator(),                1),
+        (CombineMutator(),                  1),
+        (JITStressMutator(),                1),
     ])
 
     // Construct the fuzzer instance.

--- a/Tests/FuzzilliTests/MutationsTest.swift
+++ b/Tests/FuzzilliTests/MutationsTest.swift
@@ -81,7 +81,7 @@ class MutationsTests: XCTestCase {
         program.types = ProgramTypes(from: VariableMap(types), in: program, quality: .runtime)
 
         // Mutate only 3rd instruction
-        let mutatedProgram = InputMutator().mockMutate(program, for: fuzzer, at: 3)
+        let mutatedProgram = InputMutator(isTypeAware: false).mockMutate(program, for: fuzzer, at: 3)
 
         // v3 was mutated, we should discard this type
         // v4 depends on mutated v3, but for now we keep its type

--- a/Tests/FuzzilliTests/ProgramBuilderTest.swift
+++ b/Tests/FuzzilliTests/ProgramBuilderTest.swift
@@ -194,7 +194,7 @@ class ProgramBuilderTests: XCTestCase {
                 b.blockStatement {
                     let innermostVar = b.loadInt(1)
                     XCTAssertEqual(b.randVar(), innermostVar)
-                    XCTAssertEqual(b.randVarInternal(fromOuterScope: true), nil)
+                    XCTAssertEqual(b.randVarInternal(excludeInnermostScope: true), nil)
                 }
             }
         }
@@ -209,7 +209,7 @@ class ProgramBuilderTests: XCTestCase {
                 let outerScopeVar = b.loadFloat(13.37)
                 b.blockStatement {
                     let _ = b.loadInt(100)
-                    XCTAssertEqual(b.randVarFromOuterScope(), outerScopeVar)
+                    XCTAssertEqual(b.randVar(excludeInnermostScope: true), outerScopeVar)
                 }
             }
         }
@@ -221,13 +221,13 @@ class ProgramBuilderTests: XCTestCase {
 
         b.blockStatement {
             let var1 = b.loadString("HelloWorld")
-            XCTAssertEqual(b.randVarInternal({ $0 == var1 }), var1)
+            XCTAssertEqual(b.randVarInternal(filter: { $0 == var1 }), var1)
             b.blockStatement {
                 let var2 = b.loadFloat(13.37)
-                XCTAssertEqual(b.randVarInternal({ $0 == var2 }), var2)
+                XCTAssertEqual(b.randVarInternal(filter: { $0 == var2 }), var2)
                 b.blockStatement {
                     let var3 = b.loadInt(100)
-                    XCTAssertEqual(b.randVarInternal({ $0 == var3 }), var3)
+                    XCTAssertEqual(b.randVarInternal(filter: { $0 == var3 }), var3)
                 }
             }
         }
@@ -240,13 +240,13 @@ class ProgramBuilderTests: XCTestCase {
         let var0 = b.loadInt(1337)
         b.blockStatement {
             let var1 = b.loadString("HelloWorld")
-            XCTAssertEqual(b.randVarInternal({ $0 == var0 }, fromOuterScope : true), var0)
+            XCTAssertEqual(b.randVarInternal(filter: { $0 == var0 }, excludeInnermostScope : true), var0)
             b.blockStatement {
                 let var2 = b.loadFloat(13.37)
-                XCTAssertEqual(b.randVarInternal({ $0 == var1 }, fromOuterScope : true), var1)
+                XCTAssertEqual(b.randVarInternal(filter: { $0 == var1 }, excludeInnermostScope : true), var1)
                 b.blockStatement {
                     let _ = b.loadInt(100)
-                    XCTAssertEqual(b.randVarInternal({ $0 == var2 }, fromOuterScope : true), var2)
+                    XCTAssertEqual(b.randVarInternal(filter: { $0 == var2 }, excludeInnermostScope : true), var2)
                 }
             }
         }


### PR DESCRIPTION
This change removes the ability to rewire inputs directly during splicing,
which is fairly complicated, and instead adds a TypeAwareInputMutator which
behaves like the InputMutator except that it takes type information into
account and attempts to find "compatible" inputs. The idea here is that
splicing with rewiring is roughly equivalent to a simple splicing followed by
an input mutation.