### PR TITLE
Fuzzilli: use `libsocket.socket_recv` instead of `read`

### DIFF
--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -231,7 +231,7 @@ class Connection {
         var numBytesRead = 0
         var gotData = false
         repeat {
-            numBytesRead = read(socket, receiveBuffer.baseAddress, receiveBuffer.count)
+            numBytesRead = socket_recv(socket, receiveBuffer.baseAddress, receiveBuffer.count)
             if numBytesRead > 0 {
                 gotData = true
                 currentMessageData.append(receiveBuffer.baseAddress!, count: numBytesRead)


### PR DESCRIPTION
This is a cleanup change that uses `socket_recv` instead of a raw `read`
from the libc.  THe intent here is to be able to support Windows which
has a separate sockets library  which is not part of libc.