### PR TITLE
Fuzzilli: replace `sleep` with `Thread.sleep(forTimeInterval:)`

### DIFF
--- a/Sources/Fuzzilli/Execution/REPRL.swift
+++ b/Sources/Fuzzilli/Execution/REPRL.swift
@@ -116,7 +116,7 @@ public class REPRL: ComponentBase, ScriptRunner {
                 if fuzzer.config.enableDiagnostics {
                     fuzzer.dispatchEvent(fuzzer.events.DiagnosticsEvent, data: (name: "REPRLFail", content: scriptBuffer))
                 }
-                sleep(1)
+                Thread.sleep(forTimeInterval: 1)
                 status = reprl_execute(reprlContext, $0, UInt64(script.count), UInt64(timeout), &execTime, 1)
             }
         }

--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -654,7 +654,7 @@ public class NetworkWorker: Module, MessageHandler {
                 break
             } else {
                 logger.warning("Failed to connect to master. Retrying in 30 seconds")
-                sleep(30)
+                Thread.sleep(forTimeInterval: 30)
             }
         }
         if fd < 0 {

--- a/Sources/Fuzzilli/Modules/ThreadSync.swift
+++ b/Sources/Fuzzilli/Modules/ThreadSync.swift
@@ -70,7 +70,7 @@ public class ThreadMaster: Module {
             worker.registerEventListener(for: worker.events.ShutdownComplete) { _ in
                 self.shutdownGroup.leave()
                 // The master instance is responsible for terminating the process, so just sleep here now.
-                while true { sleep(60) }
+                while true { Thread.sleep(forTimeInterval: 60) }
             }
         }
     }


### PR DESCRIPTION
Windows does not have a `sleep` function in the C library, though it does
provide a `Sleep` function in the Windows SDK.  Rather than having two separate
paths here, use the Foundation provided wrapper `Thread.sleep(forTimeInterval:)`
as a portable alternative.