### PR TITLE
Fuzzilli: adapt `NetworkSync` for libsocket changes

### DIFF
--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -78,7 +78,7 @@ protocol MessageHandler {
 /// A connection to a network peer that speaks the above protocol.
 class Connection {
     /// File descriptor of the socket.
-    let socket: socket_t
+    let socket: libsocket.socket_t
     
     // Whether this connection has been closed.
     private(set) var closed = false
@@ -104,7 +104,7 @@ class Connection {
     /// Pending outgoing data. Must only be accessed on this connection's dispatch queue.
     private var sendQueue: [Data] = []
     
-    init(socket: socket_t, handler: MessageHandler) {
+    init(socket: libsocket.socket_t, handler: MessageHandler) {
         self.socket = socket
         self.handler = handler
         self.queue = DispatchQueue(label: "Socket \(socket)")
@@ -302,9 +302,9 @@ class Connection {
 public class NetworkMaster: Module, MessageHandler {
     /// File descriptor of the server socket.
 #if os(Windows)
-    private var serverFd: socket_t = INVALID_SOCKET
+    private var serverFd: libsocket.socket_t = INVALID_SOCKET
 #else
-    private var serverFd: socket_t = -1
+    private var serverFd: libsocket.socket_t = -1
 #endif
     
     /// Associated fuzzer.
@@ -323,7 +323,7 @@ public class NetworkMaster: Module, MessageHandler {
     private var serverQueue: DispatchQueue? = nil
     
     /// Active workers. The key is the socket filedescriptor number.
-    private var workers = [socket_t: Worker]()
+    private var workers = [libsocket.socket_t: Worker]()
     
     /// Since fuzzer state can grow quite large (> 100MB) and takes long to serialize,
     /// we cache the serialized state for a short time.
@@ -397,7 +397,7 @@ public class NetworkMaster: Module, MessageHandler {
         }
     }
 
-    private func handleNewConnection(_ socket: socket_t) {
+    private func handleNewConnection(_ socket: libsocket.socket_t) {
         guard socket > 0 else {
             return logger.error("Failed to accept client connection")
         }
@@ -664,9 +664,9 @@ public class NetworkWorker: Module, MessageHandler {
     
     private func connect() {
 #if os(Windows)
-        var fd: socket_t = INVALID_SOCKET
+        var fd: libsocket.socket_t = INVALID_SOCKET
 #else
-        var fd: socket_t = -1
+        var fd: libsocket.socket_t = -1
 #endif
         for _ in 0..<10 {
             fd = libsocket.socket_connect(masterHostname, masterPort)

--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -16,7 +16,7 @@ import Foundation
 import libsocket
 
 #if !os(Windows)
-fileprivate INVALID_SOCKET: libsocket.socket_t = libsocket.socket_t(bitPattern: -1)
+fileprivate let INVALID_SOCKET: libsocket.socket_t = libsocket.socket_t(bitPattern: -1)
 #endif
 
 /// Module for synchronizing over the network.

--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -15,10 +15,6 @@
 import Foundation
 import libsocket
 
-#if !os(Windows)
-fileprivate let INVALID_SOCKET: libsocket.socket_t = libsocket.socket_t(bitPattern: -1)
-#endif
-
 /// Module for synchronizing over the network.
 ///
 /// This module implementes a simple TCP-based protocol

--- a/Sources/libsocket/include/libsocket.h
+++ b/Sources/libsocket/include/libsocket.h
@@ -37,6 +37,7 @@ typedef __typeof__(_Generic((size_t)0,                                  \
 #endif
 #else
 typedef int socket_t;
+#define INVALID_SOCKET (-1)
 #endif
 
 socket_t socket_listen(const char* address, uint16_t port);

--- a/Sources/libsocket/socket-posix.c
+++ b/Sources/libsocket/socket-posix.c
@@ -112,7 +112,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
     freeaddrinfo(result);
 
     if (addr == NULL) {
-       return -2;
+       return -1;
     }
     
 #ifdef  __APPLE__
@@ -123,11 +123,11 @@ socket_t socket_connect(const char* address, uint16_t port) {
     int flags = fcntl(fd, F_GETFL, 0);
     if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
         close(fd);
-        return -3;
+        return -1;
     }
     if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
         close(fd);
-        return -4;
+        return -1;
     }
 
     return fd;

--- a/Sources/libsocket/socket-posix.c
+++ b/Sources/libsocket/socket-posix.c
@@ -27,7 +27,7 @@
 socket_t socket_listen(const char* address, uint16_t port) {
     socket_t fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {
-        return -1;
+        return INVALID_SOCKET;
     }
     
     int arg = 1;
@@ -36,7 +36,7 @@ socket_t socket_listen(const char* address, uint16_t port) {
     int flags = fcntl(fd, F_GETFL, 0);
     if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
         close(fd);
-        return -2;
+        return INVALID_SOCKET;
     }
     
     struct sockaddr_in serv_addr;
@@ -47,7 +47,7 @@ socket_t socket_listen(const char* address, uint16_t port) {
     
     if (bind(fd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
         close(fd);
-        return -3;
+        return INVALID_SOCKET;
     }
     
     listen(fd, 256);
@@ -57,7 +57,7 @@ socket_t socket_listen(const char* address, uint16_t port) {
 socket_t socket_accept(socket_t fd) {
     socket_t client_fd = accept(fd, NULL, 0);
     if (client_fd < 0) {
-        return -1;
+        return INVALID_SOCKET;
     }
     
 #ifdef  __APPLE__
@@ -68,11 +68,11 @@ socket_t socket_accept(socket_t fd) {
     int flags = fcntl(client_fd, F_GETFL, 0);
     if (fcntl(client_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
         close(client_fd);
-        return -2;
+        return INVALID_SOCKET;
     }
     if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
         close(fd);
-        return -3;
+        return INVALID_SOCKET;
     }
     
     return client_fd;
@@ -90,7 +90,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
     
     struct addrinfo* result;
     if (getaddrinfo (address, portbuf, &hint, &result) != 0) {
-        return -1;
+        return INVALID_SOCKET;
     }
 
     socket_t fd;
@@ -112,7 +112,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
     freeaddrinfo(result);
 
     if (addr == NULL) {
-       return -1;
+       return INVALID_SOCKET;
     }
     
 #ifdef  __APPLE__
@@ -123,11 +123,11 @@ socket_t socket_connect(const char* address, uint16_t port) {
     int flags = fcntl(fd, F_GETFL, 0);
     if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
         close(fd);
-        return -1;
+        return INVALID_SOCKET;
     }
     if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
         close(fd);
-        return -1;
+        return INVALID_SOCKET;
     }
 
     return fd;


### PR DESCRIPTION
Update the `NetworkSync` implementation to use the new `socket_t` type.
Additionally, adjust the dispatch usage to use the Windows extensions to
properly handle the socket source registration.