### PR TITLE
change header guards for conformance to standard

### DIFF
--- a/Sources/libcoverage/include/libcoverage.h
+++ b/Sources/libcoverage/include/libcoverage.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __LIBCOVERAGE_H__
-#define __LIBCOVERAGE_H__
+#ifndef LIBCOVERAGE_H
+#define LIBCOVERAGE_H
 
 #include <stdint.h>
 #include <sys/types.h>

--- a/Sources/libreprl/include/libreprl.h
+++ b/Sources/libreprl/include/libreprl.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __LIBREPRL_H__
-#define __LIBREPRL_H__
+#ifndef LIBREPRL_H
+#define LIBREPRL_H
 
 #include <stdint.h>
 

--- a/Sources/libsocket/include/libsocket.h
+++ b/Sources/libsocket/include/libsocket.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __LIBSOCKET_H__
-#define __LIBSOCKET_H__
+#ifndef LIBSOCKET_H
+#define LIBSOCKET_H
 
 #include <stdint.h>
 #include <sys/types.h>


### PR DESCRIPTION
The C standard indicates that identifiers which begin with `__` are reserved for
the implementation.  Adjust the include guards to use unreseved identifiers.