### PR TITLE
workflows: add Linux build

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,4 +1,4 @@
-name: Swift
+name: build
 
 on:
   push:
@@ -7,13 +7,25 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  macOS:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: swift build -v
-    - name: Run tests
-      run: swift test -v
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -v
+      - name: Run tests
+        run: swift test -v
+
+  linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: fwal/setup-swift@v1.8.0
+      - name: Swift Version
+        run: swift --version
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -v
+      - name: Run tests
+        run: swift test -v


### PR DESCRIPTION
This adds Linux coverage to the CI to prevent accidental breakage.  The previous
changes to support Windows seems to have accidentally regressed Linux builds.
Add coverage to prevent that in the future.