### PR TITLE
Fuzzilli: explicitly import `uuid_t` for Windows

### DIFF
--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -14,6 +14,8 @@
 
 import Foundation
 import libsocket
+// Explicitly import `Foundation.UUID` to avoid the conflict with `WinSDK.UUID`
+import struct Foundation.UUID
 
 /// Module for synchronizing over the network.
 ///


### PR DESCRIPTION
`uuid_t` on Windows is problematic as there is a definition vended by
Foundation and WinSDK.  Explicitly import `uuid_t` from Foundation to
resolve the ambiguity.