### PR TITLE
libcoverage: correct variable reference

### DIFF
--- a/Sources/libcoverage/coverage.c
+++ b/Sources/libcoverage/coverage.c
@@ -73,7 +73,7 @@ int cov_initialize(struct cov_context* context)
     }
 
     context->shmem =
-            MapViewOfFIle(hMapping, FILE_MAP_ALL_ACCESS, 0, 0, SHM_SIZE);
+            MapViewOfFile(context->hMapping, FILE_MAP_ALL_ACCESS, 0, 0, SHM_SIZE);
     if (!context->shmem) {
         CloseHandle(context->hMapping);
         context->hMapping = INVALID_HANDLE_VALUE;


### PR DESCRIPTION
This variable was moved into the context, but the reference did not base
it from the context.  This corrects the reference.