### PR TITLE
Fuzzilli: silence warning on Windows

### DIFF
--- a/Sources/Fuzzilli/Util/CInterop.swift
+++ b/Sources/Fuzzilli/Util/CInterop.swift
@@ -17,7 +17,11 @@ import Foundation
 func convertToCArray(_ array: [String]) -> UnsafeMutablePointer<UnsafePointer<Int8>?> {
     let buffer = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: array.count + 1)
     for (i, str) in array.enumerated() {
+#if os(Windows)
+        buffer[i] = UnsafePointer(str.withCString(_strdup))
+#else
         buffer[i] = UnsafePointer(str.withCString(strdup))
+#endif
     }
     buffer[array.count] = nil
     return buffer


### PR DESCRIPTION
On Windows, ucrt declares `strdup` deprecated and recommends `_strdup`.
Silence the annoying warning.