### PR TITLE
Fuzzilli: port to Windows

### DIFF
--- a/Sources/Fuzzilli/Evaluation/ProgramCoverageEvaluator.swift
+++ b/Sources/Fuzzilli/Evaluation/ProgramCoverageEvaluator.swift
@@ -100,7 +100,11 @@ public class ProgramCoverageEvaluator: ComponentBase, ProgramEvaluator {
         guard libcoverage.cov_initialize(&context) == 0 else {
             fatalError("Could not initialize libcoverage")
         }
+#if os(Windows)
+        runner.setEnvironmentVariable("SHM_ID", to: "shm_id_\(GetCurrentProcessId())_\(id)")
+#else
         runner.setEnvironmentVariable("SHM_ID", to: "shm_id_\(getpid())_\(id)")
+#endif
 
     }
     


### PR DESCRIPTION
Windows does not provide a `getpid` function, but the value is used for
the name of the global mapping setup in libcoverage.  This changes it to
match the generation in libcoverge - use `GetCurrentProcessId`.