### PR TITLE
CI: add Windows build and test coverage

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,3 +29,17 @@ jobs:
         run: swift build -v
       - name: Run tests
         run: swift test -v
+
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: compnerd/gha-setup-swift
+        with:
+          branch: swift-5.5-release
+          tag: 5.5-release
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -v
+      - name: Run tests
+        run: swift test -v


### PR DESCRIPTION
Now that the Windows port is complete enough to build and pass the test
suite, add coverage to prevent regressions.