### PR TITLE
Always inline Unary Operations

### DIFF
--- a/Sources/Fuzzilli/Lifting/JSExpressions.swift
+++ b/Sources/Fuzzilli/Lifting/JSExpressions.swift
@@ -33,7 +33,7 @@ public let NumberLiteral        = ExpressionType(precedence: 17,                
 public let ObjectLiteral        = ExpressionType(precedence: 17,                        inline: .singleUseOnly)
 public let ArrayLiteral         = ExpressionType(precedence: 17,                        inline: .singleUseOnly)
 public let PostfixExpression    = ExpressionType(precedence: 16,                        inline: .singleUseOnly)
-public let UnaryExpression      = ExpressionType(precedence: 15, associativity: .right, inline: .singleUseOnly)
+public let UnaryExpression      = ExpressionType(precedence: 15, associativity: .right, inline: .always)
 public let BinaryExpression     = ExpressionType(precedence: 14, associativity: .none,  inline: .singleUseOnly)
 public let TernaryExpression    = ExpressionType(precedence: 4,  associativity: .none,  inline: .singleUseOnly)
 public let AssignmentExpression = ExpressionType(precedence: 3,                         inline: .never)
@@ -44,6 +44,6 @@ public struct InlineOnlyLiterals: InliningPolicy {
     public init() {}
     
     public func shouldInline(_ expr: Expression) -> Bool {
-        return expr.type == Literal || expr.type == NumberLiteral || expr.type == Identifier
+        return expr.type == Literal || expr.type == NumberLiteral || expr.type == Identifier || expr.type == UnaryExpression
     }
 }


### PR DESCRIPTION
Currently UnaryOperations are not inlined which make compilation to IL a bit more tedious. Consider the following program:
```
let arr = []
for(let i =0; i< 10; i++){
 arr[i++] = i
}
```
Which would compile to:
```
v0 <- CreateArray []
BeginFor v1 
    v2 <- UnaryOperation v1, '++'
    StoreComputedProperty v1, v2, v0
EndFor
```
Without inlining this IL would lift to:
```
let arr = []
for(let v1 =0; v1< 10; v1++){
 const v2 = v1++
 arr[v2] = v1
}
```
Which is incorrect. Of course this could be solved by generating additional IL instructions to emit a temporary variable and then reassign the temporary variable. Instead a more elegant solution would be to always inline UnaryOperations which saves us from unnecessary IL gymnastics with temporary variables. 