### PR TITLE
Add DestructArray and DestructArrayAndReassign operations

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -395,15 +395,27 @@ public let CodeGenerators: [CodeGenerator] = [
 
     CodeGenerator("DestructArrayGenerator", input: .iterable) { b, arr in
         // TODO: We need a way to expose the length of arr so that element selection is accurate
-        b.destruct(arr, selectFirst: Int.random(in: 0...5), hasRestElement: probability(0.2))
+        // Pick random indices
+        var indices: [Int] = []
+        for idx in 0..<Int.random(in: 0..<5) {
+            withProbability(0.7) {
+                indices.append(idx)
+            }
+        }
+
+        b.destruct(arr, selecting: indices, hasRestElement: probability(0.2))
     },
 
     CodeGenerator("DestructArrayAndReassignGenerator", input: .iterable) {b, arr in
         var candidates: [Variable] = []
-        for _ in 0..<Int.random(in: 0..<5) {
-            candidates.append(b.randVar())
+        var indices: [Int] = []
+        for idx in 0..<Int.random(in: 0..<5) {
+            withProbability(0.7) {
+                indices.append(idx)
+                candidates.append(b.randVar())
+            }
         }
-        b.destructAndReassign(candidates, to: arr, hasRestElement: probability(0.2))
+        b.destructAndReassign(candidates, atIndices: indices, from: arr, hasRestElement: probability(0.2))
     },
 
     CodeGenerator("ComparisonGenerator", inputs: (.anything, .anything)) { b, lhs, rhs in

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -394,8 +394,9 @@ public let CodeGenerators: [CodeGenerator] = [
     },
 
     CodeGenerator("DestructArrayGenerator", input: .iterable) { b, arr in
-        // TODO: We need a way to expose the length of arr so that element selection is accurate
-        // Pick random indices
+        // Fuzzilli generated arrays can have a length ranging from 0 to 10 elements,
+        // We want to ensure that 1) when destructing arrays we are within this length range
+        // and 2) The probability with which we select indices allows defining atleast 2-3 variables.
         var indices: [Int] = []
         for idx in 0..<Int.random(in: 0..<5) {
             withProbability(0.7) {

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -393,6 +393,19 @@ public let CodeGenerators: [CodeGenerator] = [
         b.reassign(target, to: val)
     },
 
+    CodeGenerator("DestructArrayGenerator", input: .iterable) { b, arr in
+        // TODO: We need a way to expose the length of arr so that element selection is accurate
+        b.destruct(arr, selectFirst: Int.random(in: 0...5))
+    },
+
+    CodeGenerator("DestructArrayAndReassignGenerator", input: .iterable) {b, arr in
+        var candidates: [Variable] = []
+        for _ in 0..<Int.random(in: 0..<5) {
+            candidates.append(b.randVar())
+        }
+        b.destructAndReassign(candidates, to: arr)
+    },
+
     CodeGenerator("ComparisonGenerator", inputs: (.anything, .anything)) { b, lhs, rhs in
         b.compare(lhs, rhs, with: chooseUniform(from: allComparators))
     },

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -395,7 +395,7 @@ public let CodeGenerators: [CodeGenerator] = [
 
     CodeGenerator("DestructArrayGenerator", input: .iterable) { b, arr in
         // TODO: We need a way to expose the length of arr so that element selection is accurate
-        b.destruct(arr, selectFirst: Int.random(in: 0...5))
+        b.destruct(arr, selectFirst: Int.random(in: 0...5), hasRestElement: probability(0.2))
     },
 
     CodeGenerator("DestructArrayAndReassignGenerator", input: .iterable) {b, arr in
@@ -403,7 +403,7 @@ public let CodeGenerators: [CodeGenerator] = [
         for _ in 0..<Int.random(in: 0..<5) {
             candidates.append(b.randVar())
         }
-        b.destructAndReassign(candidates, to: arr)
+        b.destructAndReassign(candidates, to: arr, hasRestElement: probability(0.2))
     },
 
     CodeGenerator("ComparisonGenerator", inputs: (.anything, .anything)) { b, lhs, rhs in

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -395,7 +395,7 @@ public let CodeGenerators: [CodeGenerator] = [
 
     CodeGenerator("DestructArrayGenerator", input: .iterable) { b, arr in
         // Fuzzilli generated arrays can have a length ranging from 0 to 10 elements,
-        // We want to ensure that 1) when destructing arrays we are within this length range
+        // We want to ensure that 1) when destructing arrays we are usually within this length range
         // and 2) The probability with which we select indices allows defining atleast 2-3 variables.
         var indices: [Int] = []
         for idx in 0..<Int.random(in: 0..<5) {
@@ -416,7 +416,7 @@ public let CodeGenerators: [CodeGenerator] = [
                 candidates.append(b.randVar())
             }
         }
-        b.destructAndReassign(candidates, atIndices: indices, from: arr, hasRestElement: probability(0.2))
+        b.destruct(arr, selecting: indices, into: candidates, hasRestElement: probability(0.2))
     },
 
     CodeGenerator("ComparisonGenerator", inputs: (.anything, .anything)) { b, lhs, rhs in

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1310,13 +1310,13 @@ public class ProgramBuilder {
     }
 
     @discardableResult
-    public func destruct(_ input: Variable, selectFirst numOutputs: Int) -> [Variable] {
-        let outputs = perform(DestructArray(numOutputs: numOutputs), withInputs: [input]).outputs
+    public func destruct(_ input: Variable, selectFirst numOutputs: Int, hasRestElement: Bool = false) -> [Variable] {
+        let outputs = perform(DestructArray(numOutputs: numOutputs, hasRestElement: hasRestElement), withInputs: [input]).outputs
         return Array(outputs)
     }
 
-    public func destructAndReassign(_ candidates: [Variable], to input: Variable) {
-        perform(DestructArrayAndReassign(numInputs: candidates.count), withInputs: [input] + candidates)
+    public func destructAndReassign(_ candidates: [Variable], to input: Variable, hasRestElement: Bool = false) {
+        perform(DestructArrayAndReassign(numInputs: candidates.count, hasRestElement: hasRestElement), withInputs: [input] + candidates)
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1310,13 +1310,13 @@ public class ProgramBuilder {
     }
 
     @discardableResult
-    public func destruct(_ input: Variable, selectFirst numOutputs: Int, hasRestElement: Bool = false) -> [Variable] {
-        let outputs = perform(DestructArray(numOutputs: numOutputs, hasRestElement: hasRestElement), withInputs: [input]).outputs
+    public func destruct(_ input: Variable, selecting indices: [Int], hasRestElement: Bool = false) -> [Variable] {
+        let outputs = perform(DestructArray(indices: indices, hasRestElement: hasRestElement), withInputs: [input]).outputs
         return Array(outputs)
     }
 
-    public func destructAndReassign(_ candidates: [Variable], to input: Variable, hasRestElement: Bool = false) {
-        perform(DestructArrayAndReassign(numInputs: candidates.count, hasRestElement: hasRestElement), withInputs: [input] + candidates)
+    public func destructAndReassign(_ candidates: [Variable], atIndices indices: [Int], from input: Variable, hasRestElement: Bool = false) {
+        perform(DestructArrayAndReassign(indices: indices, hasRestElement: hasRestElement), withInputs: [input] + candidates)
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1315,8 +1315,8 @@ public class ProgramBuilder {
         return Array(outputs)
     }
 
-    public func destructAndReassign(_ candidates: [Variable], atIndices indices: [Int], from input: Variable, hasRestElement: Bool = false) {
-        perform(DestructArrayAndReassign(indices: indices, hasRestElement: hasRestElement), withInputs: [input] + candidates)
+    public func destruct(_ input: Variable, selecting indices: [Int], into outputs: [Variable], hasRestElement: Bool) {
+        perform(DestructArrayAndReassign(indices: indices, hasRestElement: hasRestElement), withInputs: [input] + outputs)
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1310,6 +1310,16 @@ public class ProgramBuilder {
     }
 
     @discardableResult
+    public func destruct(_ input: Variable, selectFirst numOutputs: Int) -> [Variable] {
+        let outputs = perform(DestructArray(numOutputs: numOutputs), withInputs: [input]).outputs
+        return Array(outputs)
+    }
+
+    public func destructAndReassign(_ candidates: [Variable], to input: Variable) {
+        perform(DestructArrayAndReassign(numInputs: candidates.count), withInputs: [input] + candidates)
+    }
+
+    @discardableResult
     public func compare(_ lhs: Variable, _ rhs: Variable, with comparator: Comparator) -> Variable {
         return perform(Compare(comparator), withInputs: [lhs, rhs]).output
     }

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -476,6 +476,12 @@ public struct AbstractInterpreter {
         case is Reassign:
             set(instr.input(0), type(ofInput: 1))
 
+        case is DestructArray:
+            instr.outputs.forEach{set($0, .unknown)}
+
+        case is DestructArrayAndReassign:
+            instr.inputs.dropFirst().forEach{set($0, .unknown)}
+
         case is Compare:
             set(instr.output, .boolean)
 

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -411,10 +411,10 @@ extension Instruction: ProtobufConvertible {
                 $0.dup = Fuzzilli_Protobuf_Dup()
             case is Reassign:
                 $0.reassign = Fuzzilli_Protobuf_Reassign()
-            case is DestructArray:
-                $0.destructArray = Fuzzilli_Protobuf_DestructArray()
-            case is DestructArrayAndReassign:
-                $0.destructArrayAndReassign = Fuzzilli_Protobuf_DestructArrayAndReassign()
+            case let op as DestructArray:
+                $0.destructArray = Fuzzilli_Protobuf_DestructArray.with { $0.hasRestElement_p = op.hasRestElement }
+            case let op as DestructArrayAndReassign:
+                $0.destructArrayAndReassign = Fuzzilli_Protobuf_DestructArrayAndReassign.with { $0.hasRestElement_p = op.hasRestElement }
             case let op as Compare:
                 $0.compare = Fuzzilli_Protobuf_Compare.with { $0.op = convertEnum(op.op, allComparators) }
             case is ConditionalOperation:
@@ -662,10 +662,10 @@ extension Instruction: ProtobufConvertible {
             op = Dup()
         case .reassign(_):
             op = Reassign()
-        case .destructArray(_):
-            op = DestructArray(numOutputs: inouts.count - 1)
-        case .destructArrayAndReassign(_):
-            op = DestructArrayAndReassign(numInputs: inouts.count - 1)
+        case .destructArray(let p):
+            op = DestructArray(numOutputs: inouts.count - 1, hasRestElement: p.hasRestElement_p)
+        case .destructArrayAndReassign(let p):
+            op = DestructArrayAndReassign(numInputs: inouts.count - 1, hasRestElement: p.hasRestElement_p)
         case .compare(let p):
             op = Compare(try convertEnum(p.op, allComparators))
         case .conditionalOperation(_):

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -411,6 +411,10 @@ extension Instruction: ProtobufConvertible {
                 $0.dup = Fuzzilli_Protobuf_Dup()
             case is Reassign:
                 $0.reassign = Fuzzilli_Protobuf_Reassign()
+            case is DestructArray:
+                $0.destructArray = Fuzzilli_Protobuf_DestructArray()
+            case is DestructArrayAndReassign:
+                $0.destructArrayAndReassign = Fuzzilli_Protobuf_DestructArrayAndReassign()
             case let op as Compare:
                 $0.compare = Fuzzilli_Protobuf_Compare.with { $0.op = convertEnum(op.op, allComparators) }
             case is ConditionalOperation:
@@ -658,6 +662,10 @@ extension Instruction: ProtobufConvertible {
             op = Dup()
         case .reassign(_):
             op = Reassign()
+        case .destructArray(_):
+            op = DestructArray(numOutputs: inouts.count - 1)
+        case .destructArrayAndReassign(_):
+            op = DestructArrayAndReassign(numInputs: inouts.count - 1)
         case .compare(let p):
             op = Compare(try convertEnum(p.op, allComparators))
         case .conditionalOperation(_):

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -412,9 +412,15 @@ extension Instruction: ProtobufConvertible {
             case is Reassign:
                 $0.reassign = Fuzzilli_Protobuf_Reassign()
             case let op as DestructArray:
-                $0.destructArray = Fuzzilli_Protobuf_DestructArray.with { $0.hasRestElement_p = op.hasRestElement }
+                $0.destructArray = Fuzzilli_Protobuf_DestructArray.with { 
+                    $0.indices = op.indices.map({ Int32($0) })
+                    $0.hasRestElement_p = op.hasRestElement
+                }
             case let op as DestructArrayAndReassign:
-                $0.destructArrayAndReassign = Fuzzilli_Protobuf_DestructArrayAndReassign.with { $0.hasRestElement_p = op.hasRestElement }
+                $0.destructArrayAndReassign = Fuzzilli_Protobuf_DestructArrayAndReassign.with {
+                    $0.indices = op.indices.map({ Int32($0) })
+                    $0.hasRestElement_p = op.hasRestElement 
+                }
             case let op as Compare:
                 $0.compare = Fuzzilli_Protobuf_Compare.with { $0.op = convertEnum(op.op, allComparators) }
             case is ConditionalOperation:
@@ -663,9 +669,9 @@ extension Instruction: ProtobufConvertible {
         case .reassign(_):
             op = Reassign()
         case .destructArray(let p):
-            op = DestructArray(numOutputs: inouts.count - 1, hasRestElement: p.hasRestElement_p)
+            op = DestructArray(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
         case .destructArrayAndReassign(let p):
-            op = DestructArrayAndReassign(numInputs: inouts.count - 1, hasRestElement: p.hasRestElement_p)
+            op = DestructArrayAndReassign(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
         case .compare(let p):
             op = Compare(try convertEnum(p.op, allComparators))
         case .conditionalOperation(_):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -653,6 +653,21 @@ class Reassign: Operation {
     }
 }
 
+/// Destructs an array into n output variables
+class DestructArray: Operation {
+    init(numOutputs: Int) {
+        super.init(numInputs: 1, numOutputs: numOutputs)
+    }
+}
+
+/// Destructs an array and reassigns the output to n existing variables
+class DestructArrayAndReassign: Operation {
+    init(numInputs: Int) {
+        // The first input is the array being destructed
+        super.init(numInputs: 1 + numInputs, numOutputs: 0)
+    }
+}
+
 // This array must be kept in sync with the Comparator Enum in operations.proto
 public enum Comparator: String {
     case equal              = "=="

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -655,22 +655,26 @@ class Reassign: Operation {
 
 /// Destructs an array into n output variables
 class DestructArray: Operation {
-    public var hasRestElement: Bool
+    let indices: [Int]
+    let hasRestElement: Bool
     
-    init(numOutputs: Int, hasRestElement: Bool) {
+    init(indices: [Int], hasRestElement: Bool) {
         self.hasRestElement = hasRestElement
-        super.init(numInputs: 1, numOutputs: numOutputs)
+        self.indices = indices
+        super.init(numInputs: 1, numOutputs: indices.count)
     }
 }
 
 /// Destructs an array and reassigns the output to n existing variables
 class DestructArrayAndReassign: Operation {
-    public var hasRestElement: Bool
+    let indices: [Int]
+    let hasRestElement: Bool
 
-    init(numInputs: Int, hasRestElement:Bool) {
+    init(indices: [Int], hasRestElement:Bool) {
+        self.indices = indices
         self.hasRestElement = hasRestElement
         // The first input is the array being destructed
-        super.init(numInputs: 1 + numInputs, numOutputs: 0)
+        super.init(numInputs: 1 + indices.count, numOutputs: 0)
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -659,6 +659,8 @@ class DestructArray: Operation {
     let hasRestElement: Bool
     
     init(indices: [Int], hasRestElement: Bool) {
+        assert(indices == indices.sorted(), "Indices must be sorted in ascending order")
+        assert(indices.count == Set(indices).count, "Indices must not have duplicates")
         self.hasRestElement = hasRestElement
         self.indices = indices
         super.init(numInputs: 1, numOutputs: indices.count)
@@ -671,6 +673,8 @@ class DestructArrayAndReassign: Operation {
     let hasRestElement: Bool
 
     init(indices: [Int], hasRestElement:Bool) {
+        assert(indices == indices.sorted(), "Indices must be sorted in ascending order")
+        assert(indices.count == Set(indices).count, "Indices must not have duplicates")
         self.indices = indices
         self.hasRestElement = hasRestElement
         // The first input is the array being destructed

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -655,14 +655,20 @@ class Reassign: Operation {
 
 /// Destructs an array into n output variables
 class DestructArray: Operation {
-    init(numOutputs: Int) {
+    public var hasRestElement: Bool
+    
+    init(numOutputs: Int, hasRestElement: Bool) {
+        self.hasRestElement = hasRestElement
         super.init(numInputs: 1, numOutputs: numOutputs)
     }
 }
 
 /// Destructs an array and reassigns the output to n existing variables
 class DestructArrayAndReassign: Operation {
-    init(numInputs: Int) {
+    public var hasRestElement: Bool
+
+    init(numInputs: Int, hasRestElement:Bool) {
+        self.hasRestElement = hasRestElement
         // The first input is the array being destructed
         super.init(numInputs: 1 + numInputs, numOutputs: 0)
     }

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -49,6 +49,8 @@ extension Operation {
             return inputIdx == 0
         case let op as UnaryOperation:
             return op.op.reassignsInput
+        case is DestructArrayAndReassign:
+            return inputIdx != 0
         default:
             return false
         }

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -230,18 +230,48 @@ public class FuzzILLifter: Lifter {
             w.emit("Reassign \(input(0)), \(input(1))")
 
         case let op as DestructArray:
-            var outputs = instr.outputs.map({ $0.identifier })
-            if outputs.count > 0 && op.hasRestElement {
-                outputs.append("...\(outputs.popLast()!)")
+            var arrayPattern: String = ""
+            if op.indices.count > 0 {
+                let outputs = instr.outputs.map({ $0.identifier })
+                var outputIndex = 0
+                assert(op.indices.count == outputs.count)
+                
+                for index in 0...op.indices.last! {
+                    if op.indices.contains(index) {
+                        if index == op.indices.last! {
+                            op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
+                        } else {
+                            arrayPattern.append(" \(outputs[Int(index)]),")
+                        }
+                        outputIndex += 1
+                    } else {
+                        arrayPattern.append(",")
+                    }
+                }
             }
-            w.emit("[\(outputs.joined(separator: ", "))] <- DestructArray \(input(0))")
+            w.emit("[\(arrayPattern)] <- DestructArray \(input(0))")
 
         case let op as DestructArrayAndReassign:
-            var outputs = instr.outputs.map({ $0.identifier })
-            if outputs.count > 0 && op.hasRestElement {
-                outputs.append("...\(outputs.popLast()!)")
+            var arrayPattern: String = ""
+            if op.indices.count > 0 {
+                let outputs = instr.inputs.dropFirst().map({ $0.identifier })
+                var outputIndex = 0
+                assert(op.indices.count == outputs.count)
+                
+                for index in 0...op.indices.last! {
+                    if op.indices.contains(index) {
+                        if index == op.indices.last! {
+                            op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
+                        } else {
+                            arrayPattern.append(" \(outputs[Int(index)]),")
+                        }
+                        outputIndex += 1
+                    } else {
+                        arrayPattern.append(",")
+                    }
+                }
             }
-            w.emit("[\(outputs.joined(separator: ", "))] <- DestructArrayAndReassign \(input(0))")
+            w.emit("[\(arrayPattern)] <- DestructArrayAndReassign \(input(0))")
 
         case let op as Compare:
             w.emit("\(instr.output) <- Compare \(input(0)), '\(op.op.token)', \(input(1))")

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -229,6 +229,14 @@ public class FuzzILLifter: Lifter {
         case is Reassign:
             w.emit("Reassign \(input(0)), \(input(1))")
 
+        case is DestructArray:
+            let outputs = instr.outputs.map({ $0.identifier }).joined(separator: ", ")
+            w.emit("[\(outputs)] <- DestructArray \(input(0))")
+
+        case is DestructArrayAndReassign:
+            let outputs = instr.outputs.map({ $0.identifier }).joined(separator: ", ")
+            w.emit("[\(outputs)] <- DestructArrayAndReassign \(input(0))")
+
         case let op as Compare:
             w.emit("\(instr.output) <- Compare \(input(0)), '\(op.op.token)', \(input(1))")
 

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -241,7 +241,7 @@ public class FuzzILLifter: Lifter {
                         if index == op.indices.last! {
                             op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
                         } else {
-                            arrayPattern.append(" \(outputs[Int(index)]),")
+                            arrayPattern.append(" \(outputs[outputIndex]),")
                         }
                         outputIndex += 1
                     } else {
@@ -263,7 +263,7 @@ public class FuzzILLifter: Lifter {
                         if index == op.indices.last! {
                             op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
                         } else {
-                            arrayPattern.append(" \(outputs[Int(index)]),")
+                            arrayPattern.append(" \(outputs[outputIndex]),")
                         }
                         outputIndex += 1
                     } else {

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -229,13 +229,19 @@ public class FuzzILLifter: Lifter {
         case is Reassign:
             w.emit("Reassign \(input(0)), \(input(1))")
 
-        case is DestructArray:
-            let outputs = instr.outputs.map({ $0.identifier }).joined(separator: ", ")
-            w.emit("[\(outputs)] <- DestructArray \(input(0))")
+        case let op as DestructArray:
+            var outputs = instr.outputs.map({ $0.identifier })
+            if outputs.count > 0 && op.hasRestElement {
+                outputs.append("...\(outputs.popLast()!)")
+            }
+            w.emit("[\(outputs.joined(separator: ", "))] <- DestructArray \(input(0))")
 
-        case is DestructArrayAndReassign:
-            let outputs = instr.inputs.dropFirst().map({ $0.identifier }).joined(separator: ", ")
-            w.emit("[\(outputs)] <- DestructArrayAndReassign \(input(0))")
+        case let op as DestructArrayAndReassign:
+            var outputs = instr.outputs.map({ $0.identifier })
+            if outputs.count > 0 && op.hasRestElement {
+                outputs.append("...\(outputs.popLast()!)")
+            }
+            w.emit("[\(outputs.joined(separator: ", "))] <- DestructArrayAndReassign \(input(0))")
 
         case let op as Compare:
             w.emit("\(instr.output) <- Compare \(input(0)), '\(op.op.token)', \(input(1))")

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -234,7 +234,7 @@ public class FuzzILLifter: Lifter {
             w.emit("[\(outputs)] <- DestructArray \(input(0))")
 
         case is DestructArrayAndReassign:
-            let outputs = instr.outputs.map({ $0.identifier }).joined(separator: ", ")
+            let outputs = instr.inputs.dropFirst().map({ $0.identifier }).joined(separator: ", ")
             w.emit("[\(outputs)] <- DestructArrayAndReassign \(input(0))")
 
         case let op as Compare:

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -419,13 +419,19 @@ public class JavaScriptLifter: Lifter {
                 let expr = AssignmentExpression.new() <> input(0) <> " = " <> input(1)
                 w.emit(expr)
 
-            case is DestructArray:
-                let outputs = instr.outputs.map({ $0.identifier }).joined(separator: ", ")
-                w.emit("\(varDecl) [\(outputs)] = \(input(0));")
+            case let op as DestructArray:
+                var outputs = instr.outputs.map({ $0.identifier })
+                if outputs.count > 0 && op.hasRestElement {
+                    outputs.append("...\(outputs.popLast()!)")
+                }
+                w.emit("\(varDecl) [\(outputs.joined(separator: ", "))] = \(input(0));")
 
-            case is DestructArrayAndReassign:
-                let outputs = instr.inputs.dropFirst().map({ $0.identifier }).joined(separator: ", ")
-                w.emit("[\(outputs)] = \(input(0));")
+            case let op as DestructArrayAndReassign:
+                var outputs = instr.inputs.dropFirst().map({ $0.identifier })
+                if outputs.count > 0 && op.hasRestElement {
+                    outputs.append("...\(outputs.popLast()!)")
+                }
+                w.emit("[\(outputs.joined(separator: ", "))] = \(input(0));")
 
             case let op as Compare:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -119,7 +119,6 @@ public class JavaScriptLifter: Lifter {
             func liftArrayPattern(operation: Operation) -> String {
                 var arrayPattern = ""
                 var outputs: [String] = []
-                var outputIndex = 0
                 var indices: [Int] = []
                 var hasRestElement: Bool = false
                 switch operation {
@@ -135,19 +134,12 @@ public class JavaScriptLifter: Lifter {
                         return arrayPattern
                 }
                 assert(indices.count == outputs.count)
-                if indices.count > 0 {
-                    for index in 0...indices.last! {
-                        if indices.contains(index) {
-                            if index == indices.last! {
-                                hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
-                            } else {
-                                arrayPattern.append("\(outputs[Int(outputIndex)]),")
-                            }
-                            outputIndex += 1
-                        } else {
-                            arrayPattern.append(" ,")
-                        }
-                    }
+                var lastIndex = 0
+                for (index, output) in zip(indices, outputs) {
+                    let skipped = index - lastIndex
+                    lastIndex = index
+                    let dots = index == indices.last! && hasRestElement ? "..." : ""
+                    arrayPattern += String(repeating: ",", count: skipped) + dots + output
                 }
 
                 return arrayPattern

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -419,6 +419,14 @@ public class JavaScriptLifter: Lifter {
                 let expr = AssignmentExpression.new() <> input(0) <> " = " <> input(1)
                 w.emit(expr)
 
+            case is DestructArray:
+                let outputs = instr.outputs.map({ $0.identifier }).joined(separator: ", ")
+                w.emit("\(varDecl) [\(outputs)] = \(input(0));")
+
+            case is DestructArrayAndReassign:
+                let outputs = instr.inputs.dropFirst().map({ $0.identifier }).joined(separator: ", ")
+                w.emit("[\(outputs)] = \(input(0));")
+
             case let op as Compare:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)
 

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -420,18 +420,48 @@ public class JavaScriptLifter: Lifter {
                 w.emit(expr)
 
             case let op as DestructArray:
-                var outputs = instr.outputs.map({ $0.identifier })
-                if outputs.count > 0 && op.hasRestElement {
-                    outputs.append("...\(outputs.popLast()!)")
+                var arrayPattern: String = ""
+                if op.indices.count > 0 {
+                    let outputs = instr.outputs.map({ $0.identifier })
+                    var outputIndex = 0;
+                    assert(op.indices.count == outputs.count)
+                
+                    for index in 0...op.indices.last! {
+                        if op.indices.contains(index) {
+                            if index == op.indices.last! {
+                                op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
+                            } else {
+                                arrayPattern.append("\(outputs[Int(outputIndex)]),")
+                            }
+                            outputIndex += 1
+                        } else {
+                            arrayPattern.append(" ,")
+                        }
+                    }
                 }
-                w.emit("\(varDecl) [\(outputs.joined(separator: ", "))] = \(input(0));")
+                w.emit("\(varDecl) [\(arrayPattern)] = \(input(0));")
 
             case let op as DestructArrayAndReassign:
-                var outputs = instr.inputs.dropFirst().map({ $0.identifier })
-                if outputs.count > 0 && op.hasRestElement {
-                    outputs.append("...\(outputs.popLast()!)")
+                var arrayPattern: String = ""
+                if op.indices.count > 0 {
+                    let outputs = instr.inputs.dropFirst().map({ $0.identifier })
+                    var outputIndex = 0;
+                    assert(op.indices.count == outputs.count)
+                
+                    for index in 0...op.indices.last! {
+                        if op.indices.contains(index) {
+                            if index == op.indices.last! {
+                                op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
+                            } else {
+                                arrayPattern.append("\(outputs[Int(outputIndex)]),")
+                            }
+                            outputIndex += 1
+                        } else {
+                            arrayPattern.append(" ,")
+                        }
+                    }
                 }
-                w.emit("[\(outputs.joined(separator: ", "))] = \(input(0));")
+                w.emit("[\(arrayPattern)] = \(input(0));")
 
             case let op as Compare:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -115,6 +115,44 @@ public class JavaScriptLifter: Lifter {
                 return expr(for: instr.input(idx))
             }
 
+            // Helper function to lift destruct array operations
+            func liftArrayPattern(operation: Operation) -> String {
+                var arrayPattern = ""
+                var outputs: [String] = []
+                var outputIndex = 0
+                var indices: [Int] = []
+                var hasRestElement: Bool = false
+                switch operation {
+                    case let op as DestructArray:
+                        outputs = instr.outputs.map({ $0.identifier })
+                        indices = op.indices
+                        hasRestElement = op.hasRestElement
+                    case let op as DestructArrayAndReassign:
+                        outputs = instr.inputs.dropFirst().map({ $0.identifier })
+                        indices = op.indices
+                        hasRestElement = op.hasRestElement
+                    default:
+                        return arrayPattern
+                }
+                assert(indices.count == outputs.count)
+                if indices.count > 0 {
+                    for index in 0...indices.last! {
+                        if indices.contains(index) {
+                            if index == indices.last! {
+                                hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
+                            } else {
+                                arrayPattern.append("\(outputs[Int(outputIndex)]),")
+                            }
+                            outputIndex += 1
+                        } else {
+                            arrayPattern.append(" ,")
+                        }
+                    }
+                }
+
+                return arrayPattern
+            }
+
             // Helper functions to lift a function definition
             func liftFunctionDefinitionParameters(_ op: BeginAnyFunctionDefinition) -> String {
                 assert(instr.op === op)
@@ -420,48 +458,10 @@ public class JavaScriptLifter: Lifter {
                 w.emit(expr)
 
             case let op as DestructArray:
-                var arrayPattern: String = ""
-                if op.indices.count > 0 {
-                    let outputs = instr.outputs.map({ $0.identifier })
-                    var outputIndex = 0;
-                    assert(op.indices.count == outputs.count)
-                
-                    for index in 0...op.indices.last! {
-                        if op.indices.contains(index) {
-                            if index == op.indices.last! {
-                                op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
-                            } else {
-                                arrayPattern.append("\(outputs[Int(outputIndex)]),")
-                            }
-                            outputIndex += 1
-                        } else {
-                            arrayPattern.append(" ,")
-                        }
-                    }
-                }
-                w.emit("\(varDecl) [\(arrayPattern)] = \(input(0));")
+                w.emit("\(varDecl) [\(liftArrayPattern(operation: op))] = \(input(0));")
 
             case let op as DestructArrayAndReassign:
-                var arrayPattern: String = ""
-                if op.indices.count > 0 {
-                    let outputs = instr.inputs.dropFirst().map({ $0.identifier })
-                    var outputIndex = 0;
-                    assert(op.indices.count == outputs.count)
-                
-                    for index in 0...op.indices.last! {
-                        if op.indices.contains(index) {
-                            if index == op.indices.last! {
-                                op.hasRestElement ? arrayPattern.append(" ...\(outputs[outputIndex])") : arrayPattern.append(" \(outputs[outputIndex])")
-                            } else {
-                                arrayPattern.append("\(outputs[Int(outputIndex)]),")
-                            }
-                            outputIndex += 1
-                        } else {
-                            arrayPattern.append(" ,")
-                        }
-                    }
-                }
-                w.emit("[\(arrayPattern)] = \(input(0));")
+                w.emit("[\(liftArrayPattern(operation: op))] = \(input(0));")
 
             case let op as Compare:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -118,21 +118,23 @@ public class OperationMutator: BaseInstructionMutator {
         case is ReassignWithBinop:
             newOp = ReassignWithBinop(chooseUniform(from: allBinaryOperators))
         case let op as DestructArray:
-            var newIndices: [Int] = []
-            for idx in 0..<Int.random(in: 0..<5) {
-                withProbability(0.7) {
-                    newIndices.append(idx)
+            var newIndices = Set(op.indices)
+            if newIndices.count > 0 {
+                newIndices.remove(newIndices.randomElement()!)
+                while newIndices.count != op.indices.count {
+                    newIndices.insert(Int.random(in: 0..<10))
                 }
             }
-            newOp = DestructArray(indices: newIndices, hasRestElement: !op.hasRestElement)
+            newOp = DestructArray(indices: newIndices.sorted(), hasRestElement: !op.hasRestElement)
         case let op as DestructArrayAndReassign:
-            var newIndices: [Int] = []
-            for idx in 0..<Int.random(in: 0..<5) {
-                withProbability(0.7) {
-                    newIndices.append(idx)
+            var newIndices = Set(op.indices)
+            if newIndices.count > 0 {
+                newIndices.remove(newIndices.randomElement()!)
+                while newIndices.count != op.indices.count {
+                    newIndices.insert(Int.random(in: 0..<10))
                 }
             }
-            newOp = DestructArrayAndReassign(indices: newIndices, hasRestElement: !op.hasRestElement)
+            newOp = DestructArrayAndReassign(indices: newIndices.sorted(), hasRestElement: !op.hasRestElement)
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))
         case is LoadFromScope:

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -117,6 +117,22 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = BinaryOperation(chooseUniform(from: allBinaryOperators))
         case is ReassignWithBinop:
             newOp = ReassignWithBinop(chooseUniform(from: allBinaryOperators))
+        case let op as DestructArray:
+            var newIndices: [Int] = []
+            for idx in 0..<Int.random(in: 0..<5) {
+                withProbability(0.7) {
+                    newIndices.append(idx)
+                }
+            }
+            newOp = DestructArray(indices: newIndices, hasRestElement: !op.hasRestElement)
+        case let op as DestructArrayAndReassign:
+            var newIndices: [Int] = []
+            for idx in 0..<Int.random(in: 0..<5) {
+                withProbability(0.7) {
+                    newIndices.append(idx)
+                }
+            }
+            newOp = DestructArrayAndReassign(indices: newIndices, hasRestElement: !op.hasRestElement)
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))
         case is LoadFromScope:

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -3083,9 +3083,12 @@ extension Fuzzilli_Protobuf_DestructArray: SwiftProtobuf.Message, SwiftProtobuf.
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try decoder.decodeRepeatedInt32Field(value: &self.indices)
-      case 2: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
+      case 1: try { try decoder.decodeRepeatedInt32Field(value: &self.indices) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasRestElement_p) }()
       default: break
       }
     }
@@ -3118,9 +3121,12 @@ extension Fuzzilli_Protobuf_DestructArrayAndReassign: SwiftProtobuf.Message, Swi
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try decoder.decodeRepeatedInt32Field(value: &self.indices)
-      case 2: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
+      case 1: try { try decoder.decodeRepeatedInt32Field(value: &self.indices) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasRestElement_p) }()
       default: break
       }
     }

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -950,6 +950,26 @@ public struct Fuzzilli_Protobuf_Reassign {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_DestructArray {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Fuzzilli_Protobuf_DestructArrayAndReassign {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_Compare {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3041,6 +3061,44 @@ extension Fuzzilli_Protobuf_Reassign: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_Reassign, rhs: Fuzzilli_Protobuf_Reassign) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_DestructArray: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DestructArray"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_DestructArray, rhs: Fuzzilli_Protobuf_DestructArray) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_DestructArrayAndReassign: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DestructArrayAndReassign"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_DestructArrayAndReassign, rhs: Fuzzilli_Protobuf_DestructArrayAndReassign) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -955,6 +955,8 @@ public struct Fuzzilli_Protobuf_DestructArray {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  public var indices: [Int32] = []
+
   public var hasRestElement_p: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -966,6 +968,8 @@ public struct Fuzzilli_Protobuf_DestructArrayAndReassign {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
+
+  public var indices: [Int32] = []
 
   public var hasRestElement_p: Bool = false
 
@@ -3073,26 +3077,32 @@ extension Fuzzilli_Protobuf_Reassign: SwiftProtobuf.Message, SwiftProtobuf._Mess
 extension Fuzzilli_Protobuf_DestructArray: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DestructArray"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "hasRestElement"),
+    1: .same(proto: "indices"),
+    2: .same(proto: "hasRestElement"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
+      case 1: try decoder.decodeRepeatedInt32Field(value: &self.indices)
+      case 2: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.indices.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.indices, fieldNumber: 1)
+    }
     if self.hasRestElement_p != false {
-      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 1)
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_DestructArray, rhs: Fuzzilli_Protobuf_DestructArray) -> Bool {
+    if lhs.indices != rhs.indices {return false}
     if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -3102,26 +3112,32 @@ extension Fuzzilli_Protobuf_DestructArray: SwiftProtobuf.Message, SwiftProtobuf.
 extension Fuzzilli_Protobuf_DestructArrayAndReassign: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DestructArrayAndReassign"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "hasRestElement"),
+    1: .same(proto: "indices"),
+    2: .same(proto: "hasRestElement"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
+      case 1: try decoder.decodeRepeatedInt32Field(value: &self.indices)
+      case 2: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.indices.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.indices, fieldNumber: 1)
+    }
     if self.hasRestElement_p != false {
-      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 1)
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_DestructArrayAndReassign, rhs: Fuzzilli_Protobuf_DestructArrayAndReassign) -> Bool {
+    if lhs.indices != rhs.indices {return false}
     if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -955,6 +955,8 @@ public struct Fuzzilli_Protobuf_DestructArray {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  public var hasRestElement_p: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -964,6 +966,8 @@ public struct Fuzzilli_Protobuf_DestructArrayAndReassign {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
+
+  public var hasRestElement_p: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3068,18 +3072,28 @@ extension Fuzzilli_Protobuf_Reassign: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Fuzzilli_Protobuf_DestructArray: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DestructArray"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "hasRestElement"),
+  ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
+      default: break
+      }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.hasRestElement_p != false {
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 1)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_DestructArray, rhs: Fuzzilli_Protobuf_DestructArray) -> Bool {
+    if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3087,18 +3101,28 @@ extension Fuzzilli_Protobuf_DestructArray: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Fuzzilli_Protobuf_DestructArrayAndReassign: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DestructArrayAndReassign"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "hasRestElement"),
+  ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularBoolField(value: &self.hasRestElement_p)
+      default: break
+      }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.hasRestElement_p != false {
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 1)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_DestructArrayAndReassign, rhs: Fuzzilli_Protobuf_DestructArrayAndReassign) -> Bool {
+    if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -257,11 +257,13 @@ message Reassign {
 }
 
 message DestructArray {
-    bool hasRestElement = 1;
+    repeated int32 indices = 1;
+    bool hasRestElement = 2;
 }
 
 message DestructArrayAndReassign {
-    bool hasRestElement = 1;
+    repeated int32 indices = 1;
+    bool hasRestElement = 2;
 }
 
 enum Comparator {

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -257,9 +257,11 @@ message Reassign {
 }
 
 message DestructArray {
+    bool hasRestElement = 1;
 }
 
 message DestructArrayAndReassign {
+    bool hasRestElement = 1;
 }
 
 enum Comparator {

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -256,6 +256,12 @@ message Dup {
 message Reassign {
 }
 
+message DestructArray {
+}
+
+message DestructArrayAndReassign {
+}
+
 enum Comparator {
     EQUAL = 0;
     STRICT_EQUAL = 1;

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -593,6 +593,22 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .reassign(newValue)}
   }
 
+  public var destructArray: Fuzzilli_Protobuf_DestructArray {
+    get {
+      if case .destructArray(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_DestructArray()
+    }
+    set {operation = .destructArray(newValue)}
+  }
+
+  public var destructArrayAndReassign: Fuzzilli_Protobuf_DestructArrayAndReassign {
+    get {
+      if case .destructArrayAndReassign(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_DestructArrayAndReassign()
+    }
+    set {operation = .destructArrayAndReassign(newValue)}
+  }
+
   public var compare: Fuzzilli_Protobuf_Compare {
     get {
       if case .compare(let v)? = operation {return v}
@@ -998,6 +1014,8 @@ public struct Fuzzilli_Protobuf_Instruction {
     case reassignWithBinop(Fuzzilli_Protobuf_ReassignWithBinop)
     case dup(Fuzzilli_Protobuf_Dup)
     case reassign(Fuzzilli_Protobuf_Reassign)
+    case destructArray(Fuzzilli_Protobuf_DestructArray)
+    case destructArrayAndReassign(Fuzzilli_Protobuf_DestructArrayAndReassign)
     case compare(Fuzzilli_Protobuf_Compare)
     case conditionalOperation(Fuzzilli_Protobuf_ConditionalOperation)
     case eval(Fuzzilli_Protobuf_Eval)
@@ -1274,6 +1292,14 @@ public struct Fuzzilli_Protobuf_Instruction {
       }()
       case (.reassign, .reassign): return {
         guard case .reassign(let l) = lhs, case .reassign(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.destructArray, .destructArray): return {
+        guard case .destructArray(let l) = lhs, case .destructArray(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.destructArrayAndReassign, .destructArrayAndReassign): return {
+        guard case .destructArrayAndReassign(let l) = lhs, case .destructArrayAndReassign(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.compare, .compare): return {
@@ -1619,6 +1645,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     95: .same(proto: "reassignWithBinop"),
     37: .same(proto: "dup"),
     38: .same(proto: "reassign"),
+    117: .same(proto: "destructArray"),
+    118: .same(proto: "destructArrayAndReassign"),
     39: .same(proto: "compare"),
     96: .same(proto: "conditionalOperation"),
     40: .same(proto: "eval"),
@@ -2966,6 +2994,32 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           self.operation = .storeSuperPropertyWithBinop(v)
         }
       }()
+      case 117: try {
+        var v: Fuzzilli_Protobuf_DestructArray?
+        var hadOneofValue = false
+        if let current = self.operation {
+          hadOneofValue = true
+          if case .destructArray(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.operation = .destructArray(v)
+        }
+      }()
+      case 118: try {
+        var v: Fuzzilli_Protobuf_DestructArrayAndReassign?
+        var hadOneofValue = false
+        if let current = self.operation {
+          hadOneofValue = true
+          if case .destructArrayAndReassign(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.operation = .destructArrayAndReassign(v)
+        }
+      }()
       default: break
       }
     }
@@ -3379,6 +3433,14 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .storeSuperPropertyWithBinop?: try {
       guard case .storeSuperPropertyWithBinop(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+    }()
+    case .destructArray?: try {
+      guard case .destructArray(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 117)
+    }()
+    case .destructArrayAndReassign?: try {
+      guard case .destructArrayAndReassign(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 118)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -1645,8 +1645,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     95: .same(proto: "reassignWithBinop"),
     37: .same(proto: "dup"),
     38: .same(proto: "reassign"),
-    117: .same(proto: "destructArray"),
-    118: .same(proto: "destructArrayAndReassign"),
+    116: .same(proto: "destructArray"),
+    117: .same(proto: "destructArrayAndReassign"),
     39: .same(proto: "compare"),
     96: .same(proto: "conditionalOperation"),
     40: .same(proto: "eval"),
@@ -2994,7 +2994,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           self.operation = .storeSuperPropertyWithBinop(v)
         }
       }()
-      case 117: try {
+      case 116: try {
         var v: Fuzzilli_Protobuf_DestructArray?
         var hadOneofValue = false
         if let current = self.operation {
@@ -3007,7 +3007,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           self.operation = .destructArray(v)
         }
       }()
-      case 118: try {
+      case 117: try {
         var v: Fuzzilli_Protobuf_DestructArrayAndReassign?
         var hadOneofValue = false
         if let current = self.operation {
@@ -3436,11 +3436,11 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     }()
     case .destructArray?: try {
       guard case .destructArray(let v)? = self.operation else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 117)
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 116)
     }()
     case .destructArrayAndReassign?: try {
       guard case .destructArrayAndReassign(let v)? = self.operation else { preconditionFailure() }
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 118)
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 117)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -82,8 +82,8 @@ message Instruction {
         ReassignWithBinop reassignWithBinop = 95;
         Dup dup = 37;
         Reassign reassign = 38;
-        DestructArray destructArray = 117;
-        DestructArrayAndReassign destructArrayAndReassign = 118;
+        DestructArray destructArray = 116;
+        DestructArrayAndReassign destructArrayAndReassign = 117;
         Compare compare = 39;
         ConditionalOperation conditionalOperation = 96;
         Eval eval = 40;

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -82,6 +82,8 @@ message Instruction {
         ReassignWithBinop reassignWithBinop = 95;
         Dup dup = 37;
         Reassign reassign = 38;
+        DestructArray destructArray = 117;
+        DestructArrayAndReassign destructArrayAndReassign = 118;
         Compare compare = 39;
         ConditionalOperation conditionalOperation = 96;
         Eval eval = 40;

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -70,6 +70,8 @@ let codeGeneratorWeights = [
     "ReassignWithBinopGenerator":               25,
     "DupGenerator":                             2,
     "ReassignmentGenerator":                    25,
+    "DestructArrayGenerator":                   2,
+    "DestructArrayAndReassignGenerator":        7,
     "WithStatementGenerator":                   5,
     "LoadFromScopeGenerator":                   4,
     "StoreToScopeGenerator":                    4,

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -70,7 +70,7 @@ let codeGeneratorWeights = [
     "ReassignWithBinopGenerator":               25,
     "DupGenerator":                             2,
     "ReassignmentGenerator":                    25,
-    "DestructArrayGenerator":                   2,
+    "DestructArrayGenerator":                   7,
     "DestructArrayAndReassignGenerator":        7,
     "WithStatementGenerator":                   5,
     "LoadFromScopeGenerator":                   4,

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -1049,13 +1049,16 @@ class LifterTests: XCTestCase {
         b.destruct(v4, selectFirst: 3)
         b.destruct(v4, selectFirst: 5)
 
+        b.destruct(v4, selectFirst: 2, hasRestElement: true)
+
         let program = b.finalize()
         let lifted_program = fuzzer.lifter.lift(program)
         let expected_program = """
         const v4 = [15,30,"Hello","World"];
         let [v5, v6, v7] = v4;
         let [v8, v9, v10, v11, v12] = v4;
-
+        let [v13, ...v14] = v4;
+        
         """
 
         XCTAssertEqual(lifted_program,expected_program)
@@ -1074,7 +1077,7 @@ class LifterTests: XCTestCase {
         let v8 = b.loadInt(1000)
         let v9 = b.loadBuiltin("JSON")
 
-        b.destructAndReassign([v8, v9], to: v4)
+        b.destructAndReassign([v8, v9], to: v4, hasRestElement: true)
 
         let program = b.finalize()
         let lifted_program = fuzzer.lifter.lift(program)
@@ -1082,7 +1085,7 @@ class LifterTests: XCTestCase {
         const v4 = [15,30,"Hello","World"];
         let v5 = 1000;
         let v6 = JSON;
-        [v5, v6] = v4;
+        [v5, ...v6] = v4;
 
         """
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -38,7 +38,7 @@ class LifterTests: XCTestCase {
         let b = fuzzer.makeBuilder()
         let lifter = FuzzILLifter()
 
-        for _ in 0..<10 {
+        for _ in 0..<100 {
             b.generate(n: 100)
             let program = b.finalize()
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -1055,9 +1055,9 @@ class LifterTests: XCTestCase {
         let lifted_program = fuzzer.lifter.lift(program)
         let expected_program = """
         const v4 = [15,30,"Hello","World"];
-        let [v5, v6] = v4;
-        let [v7, ,v8, , , v9] = v4;
-        let [v10, , ...v11] = v4;
+        let [v5,v6] = v4;
+        let [v7,,v8,,,v9] = v4;
+        let [v10,,...v11] = v4;
 
         """
 
@@ -1085,7 +1085,7 @@ class LifterTests: XCTestCase {
         const v4 = [15,30,"Hello","World"];
         let v5 = 1000;
         let v6 = JSON;
-        [v5, , ...v6] = v4;
+        [v5,,...v6] = v4;
 
         """
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -1077,7 +1077,7 @@ class LifterTests: XCTestCase {
         let v8 = b.loadInt(1000)
         let v9 = b.loadBuiltin("JSON")
 
-        b.destructAndReassign([v8, v9], atIndices: [0,2], from: v4, hasRestElement: true)
+        b.destruct(v4, selecting: [0,2], into: [v8, v9], hasRestElement: true)
 
         let program = b.finalize()
         let lifted_program = fuzzer.lifter.lift(program)

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -1046,19 +1046,19 @@ class LifterTests: XCTestCase {
         initialValues.append(b.loadString("World"))
         let v4 = b.createArray(with: initialValues)
 
-        b.destruct(v4, selectFirst: 3)
-        b.destruct(v4, selectFirst: 5)
+        b.destruct(v4, selecting: [0,1])
+        b.destruct(v4, selecting: [0,2,5])
 
-        b.destruct(v4, selectFirst: 2, hasRestElement: true)
+        b.destruct(v4, selecting: [0,2], hasRestElement: true)
 
         let program = b.finalize()
         let lifted_program = fuzzer.lifter.lift(program)
         let expected_program = """
         const v4 = [15,30,"Hello","World"];
-        let [v5, v6, v7] = v4;
-        let [v8, v9, v10, v11, v12] = v4;
-        let [v13, ...v14] = v4;
-        
+        let [v5, v6] = v4;
+        let [v7, ,v8, , , v9] = v4;
+        let [v10, , ...v11] = v4;
+
         """
 
         XCTAssertEqual(lifted_program,expected_program)
@@ -1077,7 +1077,7 @@ class LifterTests: XCTestCase {
         let v8 = b.loadInt(1000)
         let v9 = b.loadBuiltin("JSON")
 
-        b.destructAndReassign([v8, v9], to: v4, hasRestElement: true)
+        b.destructAndReassign([v8, v9], atIndices: [0,2], from: v4, hasRestElement: true)
 
         let program = b.finalize()
         let lifted_program = fuzzer.lifter.lift(program)
@@ -1085,7 +1085,7 @@ class LifterTests: XCTestCase {
         const v4 = [15,30,"Hello","World"];
         let v5 = 1000;
         let v6 = JSON;
-        [v5, ...v6] = v4;
+        [v5, , ...v6] = v4;
 
         """
 


### PR DESCRIPTION
This implementation currently does not support the following JS constructs:
* ~Nested arrays (i.e. [[a,b],c] = arr)~ To be handled during compilation
* ~holes (i.e [a,,b] = arr)~
* ~rest element (i.e. [a, ...b] = arr)~