### PR TITLE
Add array destruct support to ForOf

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -588,14 +588,12 @@ public let CodeGenerators: [CodeGenerator] = [
             }
         }
 
-        if indices.count == 0 {
-            b.forOfLoop(obj) { _ in
-                b.generateRecursive()
-            }
-        } else {
-            b.forOfLoop(obj, selecting: indices, hasRestElement: probability(0.2)) { _ in
-                b.generateRecursive()
-            }
+        if indices.isEmpty {
+            indices = [0]
+        }
+        
+        b.forOfLoop(obj, selecting: indices, hasRestElement: probability(0.2)) { _ in
+            b.generateRecursive()
         }
     },
 

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -573,6 +573,14 @@ public let CodeGenerators: [CodeGenerator] = [
     },
 
     CodeGenerator("ForOfLoopGenerator", input: .iterable) { b, obj in
+        b.forOfLoop(obj) { _ in
+            b.generateRecursive()
+        }
+    },
+
+    CodeGenerator("ForOfWithDestructLoopGenerator", input: .iterable) { b, obj in
+        // Don't run this generator in conservative mode, until we can track array element types
+        guard b.mode != .conservative else { return }
         var indices: [Int] = []
         for idx in 0..<Int.random(in: 1..<5) {
             withProbability(0.8) {

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -573,8 +573,21 @@ public let CodeGenerators: [CodeGenerator] = [
     },
 
     CodeGenerator("ForOfLoopGenerator", input: .iterable) { b, obj in
-        b.forOfLoop(obj) { _ in
-            b.generateRecursive()
+        var indices: [Int] = []
+        for idx in 0..<Int.random(in: 1..<5) {
+            withProbability(0.8) {
+                indices.append(idx)
+            }
+        }
+
+        if indices.count == 0 {
+            b.forOfLoop(obj) { _ in
+                b.generateRecursive()
+            }
+        } else {
+            b.forOfLoop(obj, selecting: indices, hasRestElement: probability(0.2)) { _ in
+                b.generateRecursive()
+            }
         }
     },
 

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1500,8 +1500,14 @@ public class ProgramBuilder {
     }
 
     public func forOfLoop(_ obj: Variable, _ body: (Variable) -> ()) {
-        let i = perform(BeginForOf(), withInputs: [obj]).innerOutput
+        let i = perform(BeginForOf(indices: [0], hasRestElement: false), withInputs: [obj]).innerOutput
         body(i)
+        perform(EndForOf())
+    }
+
+    public func forOfLoop(_ obj: Variable, selecting indices: [Int], hasRestElement: Bool = false, _ body: ([Variable]) -> ()) {
+        let instr = perform(BeginForOf(indices: indices, hasRestElement: hasRestElement), withInputs: [obj])
+        body(Array(instr.innerOutputs))
         perform(EndForOf())
     }
 

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1500,13 +1500,13 @@ public class ProgramBuilder {
     }
 
     public func forOfLoop(_ obj: Variable, _ body: (Variable) -> ()) {
-        let i = perform(BeginForOf(indices: [0], hasRestElement: false), withInputs: [obj]).innerOutput
+        let i = perform(BeginForOf(), withInputs: [obj]).innerOutput
         body(i)
         perform(EndForOf())
     }
 
     public func forOfLoop(_ obj: Variable, selecting indices: [Int], hasRestElement: Bool = false, _ body: ([Variable]) -> ()) {
-        let instr = perform(BeginForOf(indices: indices, hasRestElement: hasRestElement), withInputs: [obj])
+        let instr = perform(BeginForOfWithDestruct(indices: indices, hasRestElement: hasRestElement), withInputs: [obj])
         body(Array(instr.innerOutputs))
         perform(EndForOf())
     }

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -67,7 +67,7 @@ public struct AbstractInterpreter {
             state.pushSiblingState(typeChanges: &typeChanges)
         case is EndSwitch:
             state.mergeStates(typeChanges: &typeChanges)
-        case is BeginWhile, is BeginDoWhile, is BeginFor, is BeginForIn, is BeginForOf, is BeginAnyFunctionDefinition, is BeginCodeString:
+        case is BeginWhile, is BeginDoWhile, is BeginFor, is BeginForIn, is BeginForOf, is BeginForOfWithDestruct, is BeginAnyFunctionDefinition, is BeginCodeString:
             // Push empty state representing case when loop/function is not executed at all
             state.pushChildState()
             // Push state representing types during loop
@@ -524,6 +524,9 @@ public struct AbstractInterpreter {
             set(instr.innerOutput, .string)
 
         case is BeginForOf:
+            set(instr.innerOutput, .unknown)
+
+        case is BeginForOfWithDestruct:
             instr.innerOutputs.forEach {
                 set($0, .unknown)
             }

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -524,7 +524,9 @@ public struct AbstractInterpreter {
             set(instr.innerOutput, .string)
 
         case is BeginForOf:
-            set(instr.innerOutput, .unknown)
+            instr.innerOutputs.forEach {
+                set($0, .unknown)
+            }
 
         case is BeginCatch:
             set(instr.innerOutput, .unknown)

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -491,8 +491,10 @@ extension Instruction: ProtobufConvertible {
                 $0.beginForIn = Fuzzilli_Protobuf_BeginForIn()
             case is EndForIn:
                 $0.endForIn = Fuzzilli_Protobuf_EndForIn()
-            case let op as BeginForOf:
-                $0.beginForOf = Fuzzilli_Protobuf_BeginForOf.with {
+            case is BeginForOf:
+                $0.beginForOf = Fuzzilli_Protobuf_BeginForOf()
+            case let op as BeginForOfWithDestruct:
+                $0.beginForOfWithDestruct = Fuzzilli_Protobuf_BeginForOfWithDestruct.with {
                     $0.indices = op.indices.map({ Int32($0) })
                     $0.hasRestElement_p = op.hasRestElement
                 }
@@ -736,8 +738,10 @@ extension Instruction: ProtobufConvertible {
             op = BeginForIn()
         case .endForIn(_):
             op = EndForIn()
-        case .beginForOf(let p):
-            op = BeginForOf(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
+        case .beginForOf(_):
+            op = BeginForOf()
+        case .beginForOfWithDestruct(let p):
+            op = BeginForOfWithDestruct(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
         case .endForOf(_):
             op = EndForOf()
         case .break(_):

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -491,8 +491,11 @@ extension Instruction: ProtobufConvertible {
                 $0.beginForIn = Fuzzilli_Protobuf_BeginForIn()
             case is EndForIn:
                 $0.endForIn = Fuzzilli_Protobuf_EndForIn()
-            case is BeginForOf:
-                $0.beginForOf = Fuzzilli_Protobuf_BeginForOf()
+            case let op as BeginForOf:
+                $0.beginForOf = Fuzzilli_Protobuf_BeginForOf.with {
+                    $0.indices = op.indices.map({ Int32($0) })
+                    $0.hasRestElement_p = op.hasRestElement
+                }
             case is EndForOf:
                 $0.endForOf = Fuzzilli_Protobuf_EndForOf()
             case is Break:
@@ -733,8 +736,8 @@ extension Instruction: ProtobufConvertible {
             op = BeginForIn()
         case .endForIn(_):
             op = EndForIn()
-        case .beginForOf(_):
-            op = BeginForOf()
+        case .beginForOf(let p):
+            op = BeginForOf(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
         case .endForOf(_):
             op = EndForOf()
         case .break(_):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -994,8 +994,14 @@ class EndForIn: ControlFlowOperation {
 }
 
 class BeginForOf: ControlFlowOperation {
-    init() {
-        super.init(numInputs: 1, numInnerOutputs: 1, attributes: [.isBlockBegin, .isLoopBegin], contextOpened: [.script, .loop])
+    let indices: [Int]
+    let hasRestElement: Bool
+
+    init(indices: [Int], hasRestElement: Bool) {
+        assert(indices.count >= 1)
+        self.indices = indices
+        self.hasRestElement = hasRestElement
+        super.init(numInputs: 1, numInnerOutputs: indices.count, attributes: [.isBlockBegin, .isLoopBegin], contextOpened: [.script, .loop])
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -994,6 +994,12 @@ class EndForIn: ControlFlowOperation {
 }
 
 class BeginForOf: ControlFlowOperation {
+    init() {
+        super.init(numInputs: 1, numInnerOutputs: 1, attributes: [.isBlockBegin, .isLoopBegin], contextOpened: [.script, .loop])
+    }
+}
+
+class BeginForOfWithDestruct: ControlFlowOperation {
     let indices: [Int]
     let hasRestElement: Bool
 

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -166,7 +166,8 @@ extension Operation {
             return endOp is EndFor
         case is BeginForIn:
             return endOp is EndForIn
-        case is BeginForOf:
+        case is BeginForOf,
+            is BeginForOfWithDestruct:
             return endOp is EndForOf
         case is BeginTry:
             return endOp is BeginCatch || endOp is BeginFinally

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -383,13 +383,13 @@ public class FuzzILLifter: Lifter {
             w.decreaseIndentionLevel()
             w.emit("EndForIn")
 
-        case let op as BeginForOf:
-            if op.indices.count > 1 {
-                let outputs = instr.innerOutputs.map({ $0.identifier })
-                w.emit(" BeginForOf \(input(0)) -> [\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))]")
-            } else {
-                w.emit("BeginForOf \(input(0)) -> \(instr.innerOutput)")
-            }
+        case is BeginForOf:
+            w.emit("BeginForOf \(input(0)) -> \(instr.innerOutput)")
+            w.increaseIndentionLevel()
+
+        case let op as BeginForOfWithDestruct:
+            let outputs = instr.innerOutputs.map({ $0.identifier })
+            w.emit(" BeginForOf \(input(0)) -> [\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))]")
             w.increaseIndentionLevel()
 
         case is EndForOf:

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -383,8 +383,13 @@ public class FuzzILLifter: Lifter {
             w.decreaseIndentionLevel()
             w.emit("EndForIn")
 
-        case is BeginForOf:
-            w.emit("BeginForOf \(input(0)) -> \(instr.innerOutput)")
+        case let op as BeginForOf:
+            if op.indices.count > 1 {
+                let outputs = instr.innerOutputs.map({ $0.identifier })
+                w.emit(" BeginForOf \(input(0)) -> [\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))]")
+            } else {
+                w.emit("BeginForOf \(input(0)) -> \(instr.innerOutput)")
+            }
             w.increaseIndentionLevel()
 
         case is EndForOf:

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -614,13 +614,13 @@ public class JavaScriptLifter: Lifter {
                 w.decreaseIndentionLevel()
                 w.emit("}")
 
-            case let op as BeginForOf:
-                if op.indices.count > 1 {
-                    let outputs = instr.innerOutputs.map({ $0.identifier })
-                    w.emit("for (\(varDecl) [\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))] of \(input(0))) {")
-                } else {
-                    w.emit("for (\(decl(instr.innerOutput)) of \(input(0))) {")
-                }
+            case is BeginForOf:
+                w.emit("for (\(decl(instr.innerOutput)) of \(input(0))) {")
+                w.increaseIndentionLevel()
+
+            case let op as BeginForOfWithDestruct:
+                let outputs = instr.innerOutputs.map({ $0.identifier })
+                w.emit("for (\(varDecl) [\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))] of \(input(0))) {")
                 w.increaseIndentionLevel()
 
             case is EndForOf:

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -614,8 +614,13 @@ public class JavaScriptLifter: Lifter {
                 w.decreaseIndentionLevel()
                 w.emit("}")
 
-            case is BeginForOf:
-                w.emit("for (\(decl(instr.innerOutput)) of \(input(0))) {")
+            case let op as BeginForOf:
+                if op.indices.count > 1 {
+                    let outputs = instr.innerOutputs.map({ $0.identifier })
+                    w.emit("for (\(varDecl) [\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))] of \(input(0))) {")
+                } else {
+                    w.emit("for (\(decl(instr.innerOutput)) of \(input(0))) {")
+                }
                 w.increaseIndentionLevel()
 
             case is EndForOf:

--- a/Sources/Fuzzilli/Minimization/BlockReducer.swift
+++ b/Sources/Fuzzilli/Minimization/BlockReducer.swift
@@ -21,7 +21,8 @@ struct BlockReducer: Reducer {
                  is BeginDoWhile,
                  is BeginFor,
                  is BeginForIn,
-                 is BeginForOf:
+                 is BeginForOf,
+                 is BeginForOfWithDestruct:
                 assert(group.numBlocks == 1)
                 reduceLoop(loop: group.block(0), in: &code, with: verifier)
 

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -1313,6 +1313,16 @@ public struct Fuzzilli_Protobuf_BeginForOf {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Fuzzilli_Protobuf_BeginForOfWithDestruct {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
   public var indices: [Int32] = []
 
   public var hasRestElement_p: Bool = false
@@ -3925,6 +3935,25 @@ extension Fuzzilli_Protobuf_EndForIn: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Fuzzilli_Protobuf_BeginForOf: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BeginForOf"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_BeginForOf, rhs: Fuzzilli_Protobuf_BeginForOf) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_BeginForOfWithDestruct: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".BeginForOfWithDestruct"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "indices"),
     2: .same(proto: "hasRestElement"),
@@ -3953,7 +3982,7 @@ extension Fuzzilli_Protobuf_BeginForOf: SwiftProtobuf.Message, SwiftProtobuf._Me
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Fuzzilli_Protobuf_BeginForOf, rhs: Fuzzilli_Protobuf_BeginForOf) -> Bool {
+  public static func ==(lhs: Fuzzilli_Protobuf_BeginForOfWithDestruct, rhs: Fuzzilli_Protobuf_BeginForOfWithDestruct) -> Bool {
     if lhs.indices != rhs.indices {return false}
     if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -1313,6 +1313,10 @@ public struct Fuzzilli_Protobuf_BeginForOf {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  public var indices: [Int32] = []
+
+  public var hasRestElement_p: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -3921,18 +3925,37 @@ extension Fuzzilli_Protobuf_EndForIn: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Fuzzilli_Protobuf_BeginForOf: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BeginForOf"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "indices"),
+    2: .same(proto: "hasRestElement"),
+  ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedInt32Field(value: &self.indices) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasRestElement_p) }()
+      default: break
+      }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.indices.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.indices, fieldNumber: 1)
+    }
+    if self.hasRestElement_p != false {
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_BeginForOf, rhs: Fuzzilli_Protobuf_BeginForOf) -> Bool {
+    if lhs.indices != rhs.indices {return false}
+    if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -385,6 +385,9 @@ message EndForIn {
 }
 
 message BeginForOf {
+}
+
+message BeginForOfWithDestruct {
     repeated int32 indices = 1;
     bool hasRestElement = 2;
 }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -385,6 +385,8 @@ message EndForIn {
 }
 
 message BeginForOf {
+    repeated int32 indices = 1;
+    bool hasRestElement = 2;
 }
 
 message EndForOf {

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -849,6 +849,14 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .beginForOf(newValue)}
   }
 
+  public var beginForOfWithDestruct: Fuzzilli_Protobuf_BeginForOfWithDestruct {
+    get {
+      if case .beginForOfWithDestruct(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_BeginForOfWithDestruct()
+    }
+    set {operation = .beginForOfWithDestruct(newValue)}
+  }
+
   public var endForOf: Fuzzilli_Protobuf_EndForOf {
     get {
       if case .endForOf(let v)? = operation {return v}
@@ -1046,6 +1054,7 @@ public struct Fuzzilli_Protobuf_Instruction {
     case beginForIn(Fuzzilli_Protobuf_BeginForIn)
     case endForIn(Fuzzilli_Protobuf_EndForIn)
     case beginForOf(Fuzzilli_Protobuf_BeginForOf)
+    case beginForOfWithDestruct(Fuzzilli_Protobuf_BeginForOfWithDestruct)
     case endForOf(Fuzzilli_Protobuf_EndForOf)
     case `break`(Fuzzilli_Protobuf_Break)
     case `continue`(Fuzzilli_Protobuf_Continue)
@@ -1422,6 +1431,10 @@ public struct Fuzzilli_Protobuf_Instruction {
         guard case .beginForOf(let l) = lhs, case .beginForOf(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
+      case (.beginForOfWithDestruct, .beginForOfWithDestruct): return {
+        guard case .beginForOfWithDestruct(let l) = lhs, case .beginForOfWithDestruct(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
       case (.endForOf, .endForOf): return {
         guard case .endForOf(let l) = lhs, case .endForOf(let r) = rhs else { preconditionFailure() }
         return l == r
@@ -1677,6 +1690,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     54: .same(proto: "beginForIn"),
     55: .same(proto: "endForIn"),
     56: .same(proto: "beginForOf"),
+    103: .same(proto: "beginForOfWithDestruct"),
     57: .same(proto: "endForOf"),
     58: .same(proto: "break"),
     59: .same(proto: "continue"),
@@ -2942,6 +2956,19 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           self.operation = .createTemplateString(v)
         }
       }()
+      case 103: try {
+        var v: Fuzzilli_Protobuf_BeginForOfWithDestruct?
+        var hadOneofValue = false
+        if let current = self.operation {
+          hadOneofValue = true
+          if case .beginForOfWithDestruct(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.operation = .beginForOfWithDestruct(v)
+        }
+      }()
       case 112: try {
         var v: Fuzzilli_Protobuf_StorePropertyWithBinop?
         var hadOneofValue = false
@@ -3417,6 +3444,10 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .createTemplateString?: try {
       guard case .createTemplateString(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
+    }()
+    case .beginForOfWithDestruct?: try {
+      guard case .beginForOfWithDestruct(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 103)
     }()
     case .storePropertyWithBinop?: try {
       guard case .storePropertyWithBinop(let v)? = self.operation else { preconditionFailure() }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -114,6 +114,7 @@ message Instruction {
         BeginForIn beginForIn = 54;
         EndForIn endForIn = 55;
         BeginForOf beginForOf = 56;
+        BeginForOfWithDestruct beginForOfWithDestruct = 103;
         EndForOf endForOf = 57;
         Break break = 58;
         Continue continue = 59;

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -89,6 +89,7 @@ let codeGeneratorWeights = [
     "ForLoopGenerator":                         20,
     "ForInLoopGenerator":                       10,
     "ForOfLoopGenerator":                       10,
+    "ForOfWithDestructLoopGenerator":           3,
     "BreakGenerator":                           5,
     "ContinueGenerator":                        5,
     "TryCatchGenerator":                        5,

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -1091,6 +1091,42 @@ class LifterTests: XCTestCase {
 
         XCTAssertEqual(lifted_program,expected_program)
     }
+
+    func testForLoopWithArrayDestructLifting() {
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+        let v0 = b.loadInt(10)
+        let v1 = b.createArray(with: [v0,v0,v0])
+        let v2 = b.loadInt(20)
+        let v3 = b.createArray(with: [v2,v2,v2])
+        let v4 = b.createArray(with: [v1,v3])
+
+        b.forOfLoop(v4, selecting: [0,2], hasRestElement: true) { args in
+            let v8 = b.binary(args[0], b.loadInt(30), with: BinaryOperator.Add)
+            let v9 = b.callMethod("push", on: args[1], withArgs: [v8])
+            b.forOfLoop(v9) { arg in
+                b.binary(arg, b.loadFloat(4.0), with: BinaryOperator.Sub)
+            }
+        }
+
+        let program = b.finalize()
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        const v1 = [10,10,10];
+        const v3 = [20,20,20];
+        const v4 = [v1,v3];
+        for (let [v5,,...v6] of v4) {
+            const v8 = v5 + 30;
+            const v9 = v6.push(v8);
+            for (const v10 of v9) {
+                const v12 = v10 - 4.0;
+            }
+        }
+
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
 }
 
 extension LifterTests {
@@ -1125,6 +1161,7 @@ extension LifterTests {
             ("testSuperPropertyWithBinopLifting", testSuperPropertyWithBinopLifting),
             ("testArrayDestructLifting",testArrayDestructLifting),
             ("testArrayDestructAndReassignLifting", testArrayDestructAndReassignLifting),
+            ("testForLoopWithArrayDestructLifting", testForLoopWithArrayDestructLifting),
         ]
     }
 }

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -1107,6 +1107,8 @@ class LifterTests: XCTestCase {
             b.forOfLoop(v9) { arg in
                 b.binary(arg, b.loadFloat(4.0), with: BinaryOperator.Sub)
             }
+            b.forOfLoop(v4, selecting: [1]) { _ in
+            }
         }
 
         let program = b.finalize()
@@ -1120,6 +1122,8 @@ class LifterTests: XCTestCase {
             const v9 = v6.push(v8);
             for (const v10 of v9) {
                 const v12 = v10 - 4.0;
+            }
+            for (let [,v13] of v4) {
             }
         }
 


### PR DESCRIPTION
This PR allows us to generate for-of loops of the form:
```js
let arr = [[key,value], [key,value]]
for( let [x,y] of arr ){
// stuff
}
```