### PR TITLE
Add DestructObject and DestructObjectAndReassign operations

### DIFF
--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -421,21 +421,15 @@ public let CodeGenerators: [CodeGenerator] = [
 
     CodeGenerator("DestructObjectGenerator", input: .object()) { b, obj in
         var properties = Set<String>()
-        for _ in 0...5 {
-            if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop){
+        for _ in 0..<Int.random(in: 2...6) {
+            if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop) {
                 properties.insert(prop)
+            } else {
+                properties.insert(b.genPropertyNameForRead())
             }
         }
 
-        // If we haven't added any properties, add a random property name
-        if properties.isEmpty {
-            properties.insert(b.genPropertyNameForRead())
-        }
-
         let hasRestElement = probability(0.2)
-
-        // Ensure that we have at least one output
-        guard !properties.isEmpty || hasRestElement else { return }
 
         b.destruct(obj, selecting: properties.sorted(), hasRestElement: hasRestElement)
     },
@@ -443,24 +437,17 @@ public let CodeGenerators: [CodeGenerator] = [
     CodeGenerator("DestructObjectAndReassignGenerator", input: .object()) { b, obj in
         var candidates: [Variable] = []
         var properties = Set<String>()
-        for _ in 0...5 {
-            if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop){
+        for _ in 0..<Int.random(in: 2...6) {
+            if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop) {
                 properties.insert(prop)
+                candidates.append(b.randVar())
+            } else {
+                properties.insert(b.genPropertyNameForRead())
                 candidates.append(b.randVar())
             }
         }
 
-        // If we haven't added any properties, add a random property name
-        if properties.isEmpty {
-            properties.insert(b.genPropertyNameForRead())
-            candidates.append(b.randVar())
-        }
-
         let hasRestElement = probability(0.2)
-
-        // Ensure that we have at least one input variable to reassign
-        guard !properties.isEmpty || hasRestElement else { return }
-
         if hasRestElement {
             candidates.append(b.randVar())
         }

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -419,6 +419,40 @@ public let CodeGenerators: [CodeGenerator] = [
         b.destruct(arr, selecting: indices, into: candidates, hasRestElement: probability(0.2))
     },
 
+    CodeGenerator("DestructObjectGenerator", input: .object()) { b, obj in
+        var properties = Set<String>()
+        for _ in 0..<Int.random(in: 0...b.type(of: obj).numProperties) {
+            properties.insert(b.type(of: obj).randomProperty()!)
+        }
+
+        let hasRestElement = probability(0.2)
+
+        // Ensure that we have at least one output
+        guard !properties.isEmpty || hasRestElement else { return }
+
+        b.destruct(obj, selecting: properties.sorted(), hasRestElement: hasRestElement)
+    },
+
+    CodeGenerator("DestructObjectAndReassignGenerator", input: .object()) { b, obj in
+        var candidates: [Variable] = []
+        var properties = Set<String>()
+        for _ in 0..<Int.random(in: 0...b.type(of: obj).numProperties) {
+            properties.insert(b.type(of: obj).randomProperty()!)
+            candidates.append(b.randVar())
+        }
+
+        let hasRestElement = probability(0.2)
+
+        // Ensure that we have at least one input variable to reassign
+        guard !properties.isEmpty || hasRestElement else { return }
+
+        if hasRestElement {
+            candidates.append(b.randVar())
+        }
+
+        b.destruct(obj, selecting: properties.sorted(), into: candidates, hasRestElement: hasRestElement)
+    },
+
     CodeGenerator("ComparisonGenerator", inputs: (.anything, .anything)) { b, lhs, rhs in
         b.compare(lhs, rhs, with: chooseUniform(from: allComparators))
     },

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -435,16 +435,17 @@ public let CodeGenerators: [CodeGenerator] = [
     },
 
     CodeGenerator("DestructObjectAndReassignGenerator", input: .object()) { b, obj in
-        var candidates: [Variable] = []
         var properties = Set<String>()
         for _ in 0..<Int.random(in: 2...6) {
             if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop) {
                 properties.insert(prop)
-                candidates.append(b.randVar())
             } else {
                 properties.insert(b.genPropertyNameForRead())
-                candidates.append(b.randVar())
             }
+        }
+
+        var candidates = properties.map{ _ in
+            b.randVar()
         }
 
         let hasRestElement = probability(0.2)

--- a/Sources/Fuzzilli/Core/CodeGenerators.swift
+++ b/Sources/Fuzzilli/Core/CodeGenerators.swift
@@ -421,8 +421,15 @@ public let CodeGenerators: [CodeGenerator] = [
 
     CodeGenerator("DestructObjectGenerator", input: .object()) { b, obj in
         var properties = Set<String>()
-        for _ in 0..<Int.random(in: 0...b.type(of: obj).numProperties) {
-            properties.insert(b.type(of: obj).randomProperty()!)
+        for _ in 0...5 {
+            if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop){
+                properties.insert(prop)
+            }
+        }
+
+        // If we haven't added any properties, add a random property name
+        if properties.isEmpty {
+            properties.insert(b.genPropertyNameForRead())
         }
 
         let hasRestElement = probability(0.2)
@@ -436,8 +443,16 @@ public let CodeGenerators: [CodeGenerator] = [
     CodeGenerator("DestructObjectAndReassignGenerator", input: .object()) { b, obj in
         var candidates: [Variable] = []
         var properties = Set<String>()
-        for _ in 0..<Int.random(in: 0...b.type(of: obj).numProperties) {
-            properties.insert(b.type(of: obj).randomProperty()!)
+        for _ in 0...5 {
+            if let prop = b.type(of: obj).properties.randomElement(), !properties.contains(prop){
+                properties.insert(prop)
+                candidates.append(b.randVar())
+            }
+        }
+
+        // If we haven't added any properties, add a random property name
+        if properties.isEmpty {
+            properties.insert(b.genPropertyNameForRead())
             candidates.append(b.randVar())
         }
 

--- a/Sources/Fuzzilli/Core/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Core/ProgramBuilder.swift
@@ -1315,8 +1315,18 @@ public class ProgramBuilder {
         return Array(outputs)
     }
 
-    public func destruct(_ input: Variable, selecting indices: [Int], into outputs: [Variable], hasRestElement: Bool) {
+    public func destruct(_ input: Variable, selecting indices: [Int], into outputs: [Variable], hasRestElement: Bool = false) {
         perform(DestructArrayAndReassign(indices: indices, hasRestElement: hasRestElement), withInputs: [input] + outputs)
+    }
+
+    @discardableResult
+    public func destruct(_ input: Variable, selecting properties: [String], hasRestElement: Bool = false) -> [Variable] {
+        let outputs = perform(DestructObject(properties: properties, hasRestElement: hasRestElement), withInputs: [input]).outputs
+        return Array(outputs)
+    }
+
+    public func destruct(_ input: Variable, selecting properties: [String], into outputs: [Variable], hasRestElement: Bool = false) {
+        perform(DestructObjectAndReassign(properties: properties, hasRestElement: hasRestElement), withInputs: [input] + outputs)
     }
 
     @discardableResult

--- a/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
+++ b/Sources/Fuzzilli/FuzzIL/AbstractInterpreter.swift
@@ -482,6 +482,24 @@ public struct AbstractInterpreter {
         case is DestructArrayAndReassign:
             instr.inputs.dropFirst().forEach{set($0, .unknown)}
 
+        case let op as DestructObject:
+            for (property, output) in zip(op.properties, instr.outputs) {
+                set(output, inferPropertyType(of: property, on: instr.input(0)))
+            }
+            if op.hasRestElement {
+                // TODO: Add the subset of object properties and methods captured by the rest element
+                set(instr.outputs.last!, environment.objectType)
+            }
+
+        case let op as DestructObjectAndReassign:
+            for (property, input) in zip(op.properties, instr.inputs.dropFirst()) {
+                set(input, inferPropertyType(of: property, on: instr.input(0)))
+            }
+            if op.hasRestElement {
+                // TODO: Add the subset of object properties and methods captured by the rest element
+                set(instr.inputs.last!, environment.objectType)
+            }
+
         case is Compare:
             set(instr.output, .boolean)
 

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -421,6 +421,16 @@ extension Instruction: ProtobufConvertible {
                     $0.indices = op.indices.map({ Int32($0) })
                     $0.hasRestElement_p = op.hasRestElement 
                 }
+            case let op as DestructObject:
+                $0.destructObject = Fuzzilli_Protobuf_DestructObject.with {
+                    $0.properties = op.properties
+                    $0.hasRestElement_p = op.hasRestElement
+                }
+            case let op as DestructObjectAndReassign:
+                $0.destructObjectAndReassign = Fuzzilli_Protobuf_DestructObjectAndReassign.with {
+                    $0.properties = op.properties
+                    $0.hasRestElement_p = op.hasRestElement
+                }
             case let op as Compare:
                 $0.compare = Fuzzilli_Protobuf_Compare.with { $0.op = convertEnum(op.op, allComparators) }
             case is ConditionalOperation:
@@ -679,6 +689,10 @@ extension Instruction: ProtobufConvertible {
             op = DestructArray(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
         case .destructArrayAndReassign(let p):
             op = DestructArrayAndReassign(indices: p.indices.map({ Int($0) }), hasRestElement: p.hasRestElement_p)
+        case .destructObject(let p):
+            op = DestructObject(properties: p.properties, hasRestElement: p.hasRestElement_p)
+        case .destructObjectAndReassign(let p):
+            op = DestructObjectAndReassign(properties: p.properties, hasRestElement: p.hasRestElement_p)
         case .compare(let p):
             op = Compare(try convertEnum(p.op, allComparators))
         case .conditionalOperation(_):

--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -661,8 +661,8 @@ class DestructArray: Operation {
     init(indices: [Int], hasRestElement: Bool) {
         assert(indices == indices.sorted(), "Indices must be sorted in ascending order")
         assert(indices.count == Set(indices).count, "Indices must not have duplicates")
-        self.hasRestElement = hasRestElement
         self.indices = indices
+        self.hasRestElement = hasRestElement
         super.init(numInputs: 1, numOutputs: indices.count)
     }
 }
@@ -679,6 +679,33 @@ class DestructArrayAndReassign: Operation {
         self.hasRestElement = hasRestElement
         // The first input is the array being destructed
         super.init(numInputs: 1 + indices.count, numOutputs: 0)
+    }
+}
+
+/// Destructs an object into n output variables
+class DestructObject: Operation {
+    let properties: [String]
+    let hasRestElement: Bool
+
+    init(properties: [String], hasRestElement: Bool) {
+        assert(!properties.isEmpty || hasRestElement, "Must have at least one output")
+        self.properties = properties
+        self.hasRestElement = hasRestElement
+        super.init(numInputs: 1, numOutputs: properties.count + (hasRestElement ? 1 : 0))
+    }
+}
+
+/// Destructs an object and reassigns the output to n existing variables
+class DestructObjectAndReassign: Operation {
+    let properties: [String]
+    let hasRestElement: Bool
+
+    init(properties: [String], hasRestElement:Bool) {
+        assert(!properties.isEmpty || hasRestElement, "Must have at least one input variable to reassign")
+        self.properties = properties
+        self.hasRestElement = hasRestElement
+        // The first input is the object being destructed
+        super.init(numInputs: 1 + properties.count + (hasRestElement ? 1 : 0), numOutputs: 0)
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Semantics.swift
+++ b/Sources/Fuzzilli/FuzzIL/Semantics.swift
@@ -49,7 +49,8 @@ extension Operation {
             return inputIdx == 0
         case let op as UnaryOperation:
             return op.op.reassignsInput
-        case is DestructArrayAndReassign:
+        case is DestructArrayAndReassign,
+             is DestructObjectAndReassign:
             return inputIdx != 0
         default:
             return false

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -40,6 +40,21 @@ public class FuzzILLifter: Lifter {
             return arrayPattern
         }
 
+        // Helper function to lift destruct object operations
+        func liftObjectPattern(properties: [String], outputs: [String], hasRestElement: Bool) -> String {
+            assert(outputs.count == properties.count + (hasRestElement ? 1 : 0))
+
+            var objectPattern = ""
+            for (property, output) in zip(properties, outputs) {
+                objectPattern += "\(property):\(output),"
+            }
+            if hasRestElement {
+                objectPattern += "...\(outputs.last!)"
+            }
+
+            return objectPattern
+        }
+
         switch instr.op {
         case let op as LoadInteger:
             w.emit("\(instr.output) <- LoadInteger '\(op.value)'")
@@ -248,6 +263,14 @@ public class FuzzILLifter: Lifter {
         case let op as DestructArrayAndReassign:
             let outputs = instr.inputs.dropFirst().map({ $0.identifier })        
             w.emit("[\(liftArrayPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement))] <- DestructArrayAndReassign \(input(0))")
+
+        case let op as DestructObject:
+            let outputs = instr.outputs.map({ $0.identifier })
+            w.emit("{\(liftObjectPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} <- DestructObject \(input(0))")
+
+        case let op as DestructObjectAndReassign:
+            let outputs = instr.inputs.dropFirst().map({ $0.identifier })  
+            w.emit("{\(liftObjectPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} <- DestructObjectAndReassign \(input(0))")
 
         case let op as Compare:
             w.emit("\(instr.output) <- Compare \(input(0)), '\(op.op.token)', \(input(1))")

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -40,8 +40,7 @@ public class FuzzILLifter: Lifter {
             return arrayPattern
         }
 
-        // Helper function to lift destruct object operations
-        func liftObjectPattern(properties: [String], outputs: [String], hasRestElement: Bool) -> String {
+        func liftObjectDestructPattern(properties: [String], outputs: [String], hasRestElement: Bool) -> String {
             assert(outputs.count == properties.count + (hasRestElement ? 1 : 0))
 
             var objectPattern = ""
@@ -266,11 +265,11 @@ public class FuzzILLifter: Lifter {
 
         case let op as DestructObject:
             let outputs = instr.outputs.map({ $0.identifier })
-            w.emit("{\(liftObjectPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} <- DestructObject \(input(0))")
+            w.emit("{\(liftObjectDestructPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} <- DestructObject \(input(0))")
 
         case let op as DestructObjectAndReassign:
             let outputs = instr.inputs.dropFirst().map({ $0.identifier })  
-            w.emit("{\(liftObjectPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} <- DestructObjectAndReassign \(input(0))")
+            w.emit("{\(liftObjectDestructPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} <- DestructObjectAndReassign \(input(0))")
 
         case let op as Compare:
             w.emit("\(instr.output) <- Compare \(input(0)), '\(op.op.token)', \(input(1))")

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -131,8 +131,7 @@ public class JavaScriptLifter: Lifter {
                 return arrayPattern
             }
 
-            // Helper function to lift destruct object operations
-            func liftObjectPattern(properties: [String], outputs: [String], hasRestElement: Bool) -> String {
+            func liftObjectDestructPattern(properties: [String], outputs: [String], hasRestElement: Bool) -> String {
                 assert(outputs.count == properties.count + (hasRestElement ? 1 : 0))
 
                 var objectPattern = ""
@@ -460,11 +459,11 @@ public class JavaScriptLifter: Lifter {
 
             case let op as DestructObject:
                 let outputs = instr.outputs.map({ $0.identifier })
-                w.emit("\(varDecl) {\(liftObjectPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} = \(input(0));")
+                w.emit("\(varDecl) {\(liftObjectDestructPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} = \(input(0));")
 
             case let op as DestructObjectAndReassign:
                 let outputs = instr.inputs.dropFirst().map({ $0.identifier })
-                w.emit("({\(liftObjectPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} = \(input(0)));")
+                w.emit("({\(liftObjectDestructPattern(properties: op.properties, outputs: outputs, hasRestElement: op.hasRestElement))} = \(input(0)));")
 
             case let op as Compare:
                 output = BinaryExpression.new() <> input(0) <> " " <> op.op.token <> " " <> input(1)

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -119,32 +119,70 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = ReassignWithBinop(chooseUniform(from: allBinaryOperators))
         case let op as DestructArray:
             var newIndices = Set(op.indices)
-            if newIndices.count > 0 {
-                newIndices.remove(newIndices.randomElement()!)
-                while newIndices.count != op.indices.count {
-                    newIndices.insert(Int.random(in: 0..<10))
+            var removedIndex = -1
+            if newIndices.count > 0, let idx = newIndices.randomElement() {
+                newIndices.remove(idx)
+                removedIndex = idx
+            }
+            for _ in 0...5 {
+                let idx = Int.random(in: 0..<10)
+                // Ensure that we neither add an index that already exists nor add one that we just removed
+                if newIndices.count <= op.indices.count && !newIndices.contains(idx) && idx != removedIndex {
+                    newIndices.insert(idx)
+                    break
                 }
             }
             newOp = DestructArray(indices: newIndices.sorted(), hasRestElement: !op.hasRestElement)
         case let op as DestructArrayAndReassign:
             var newIndices = Set(op.indices)
-            if newIndices.count > 0 {
-                newIndices.remove(newIndices.randomElement()!)
-                while newIndices.count != op.indices.count {
-                    newIndices.insert(Int.random(in: 0..<10))
+            var removedIndex = -1
+            if newIndices.count > 0, let idx = newIndices.randomElement() {
+                newIndices.remove(idx)
+                removedIndex = idx
+            }
+            for _ in 0...5 {
+                let idx = Int.random(in: 0..<10)
+                // Ensure that we neither add an index that already exists nor add one that we just removed
+                if newIndices.count <= op.indices.count && !newIndices.contains(idx) && idx != removedIndex {
+                    newIndices.insert(idx)
+                    break
                 }
             }
             newOp = DestructArrayAndReassign(indices: newIndices.sorted(), hasRestElement: !op.hasRestElement)
         case let op as DestructObject:
             var newProperties = Set(op.properties)
-            if newProperties.count > 0 {
-                newProperties.remove(newProperties.randomElement()!)
+            // Remove a random property
+            var removedProperty = ""
+            if newProperties.count > 0, let prop = newProperties.randomElement() {
+                removedProperty = prop
+                newProperties.remove(prop)
+            }
+            // Append a random property
+            let properties = b.type(of: instr.input(0)).properties
+            for _ in 0...5 {
+                // Ensure that we don't add the property that we just removed
+                if properties.count  > 0, let prop = properties.randomElement(), prop != removedProperty {
+                    newProperties.insert(prop)
+                    break
+                }
             }
             newOp = DestructObject(properties: newProperties.sorted(), hasRestElement: !op.hasRestElement)
         case let op as DestructObjectAndReassign:
             var newProperties = Set(op.properties)
-            if newProperties.count > 0 {
-                newProperties.remove(newProperties.randomElement()!)
+            // Remove a random property
+            var removedProperty = ""
+            if newProperties.count > 0, let prop = newProperties.randomElement() {
+                removedProperty = prop
+                newProperties.remove(prop)
+            }
+            // Append a random property
+            let properties = b.type(of: instr.input(0)).properties
+            for _ in 0...5 {
+                // Ensure that we don't add the property that we just removed
+                if properties.count  > 0, let prop = properties.randomElement(), prop != removedProperty {
+                    newProperties.insert(prop)
+                    break
+                }
             }
             newOp = DestructObjectAndReassign(properties: newProperties.sorted(), hasRestElement: !op.hasRestElement)
         case is Compare:

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -135,6 +135,18 @@ public class OperationMutator: BaseInstructionMutator {
                 }
             }
             newOp = DestructArrayAndReassign(indices: newIndices.sorted(), hasRestElement: !op.hasRestElement)
+        case let op as DestructObject:
+            var newProperties = Set(op.properties)
+            if newProperties.count > 0 {
+                newProperties.remove(newProperties.randomElement()!)
+            }
+            newOp = DestructObject(properties: newProperties.sorted(), hasRestElement: !op.hasRestElement)
+        case let op as DestructObjectAndReassign:
+            var newProperties = Set(op.properties)
+            if newProperties.count > 0 {
+                newProperties.remove(newProperties.randomElement()!)
+            }
+            newOp = DestructObjectAndReassign(properties: newProperties.sorted(), hasRestElement: !op.hasRestElement)
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))
         case is LoadFromScope:

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -28,19 +28,20 @@ public class OperationMutator: BaseInstructionMutator {
         b.trace("Mutating next operation")
 
         func replaceRandomElement<T>(in set: inout Set<T>, generatingRandomValuesWith generator: () -> T) {
-            let removedElem: T? = nil
-            if let removedElem = set.randomElement() {
-                set.remove(removedElem)
-            }
+            guard let removedElem = set.randomElement() else { return }
+            set.remove(removedElem)
 
             for _ in 0...5 {
                 let newElem = generator()
                 // Ensure that we neither add an element that already exists nor add one that we just removed
                 if !set.contains(newElem) && newElem != removedElem {
                     set.insert(newElem)
-                    break
+                    return
                 }
             }
+
+            // Failed to insert a new element, so just insert the removed element again as we must not change the size of the set
+            set.insert(removedElem)
         }
         
         switch instr.op {
@@ -143,11 +144,11 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = DestructArrayAndReassign(indices: newIndices.sorted(), hasRestElement: !op.hasRestElement)
         case let op as DestructObject:
             var newProperties = Set(op.properties)
-            replaceRandomElement(in: &newProperties, generatingRandomValuesWith: { return b.type(of: instr.input(0)).properties.randomElement() ?? b.genPropertyNameForRead() })
+            replaceRandomElement(in: &newProperties, generatingRandomValuesWith: { return b.genPropertyNameForRead() })
             newOp = DestructObject(properties: newProperties.sorted(), hasRestElement: !op.hasRestElement)
         case let op as DestructObjectAndReassign:
             var newProperties = Set(op.properties)
-            replaceRandomElement(in: &newProperties, generatingRandomValuesWith: { return b.type(of: instr.input(0)).properties.randomElement() ?? b.genPropertyNameForRead() })
+            replaceRandomElement(in: &newProperties, generatingRandomValuesWith: { return b.genPropertyNameForRead() })
             newOp = DestructObjectAndReassign(properties: newProperties.sorted(), hasRestElement: !op.hasRestElement)
         case is Compare:
             newOp = Compare(chooseUniform(from: allComparators))

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -978,6 +978,34 @@ public struct Fuzzilli_Protobuf_DestructArrayAndReassign {
   public init() {}
 }
 
+public struct Fuzzilli_Protobuf_DestructObject {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var properties: [String] = []
+
+  public var hasRestElement_p: Bool = false
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Fuzzilli_Protobuf_DestructObjectAndReassign {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var properties: [String] = []
+
+  public var hasRestElement_p: Bool = false
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Fuzzilli_Protobuf_Compare {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3170,6 +3198,82 @@ extension Fuzzilli_Protobuf_DestructArrayAndReassign: SwiftProtobuf.Message, Swi
 
   public static func ==(lhs: Fuzzilli_Protobuf_DestructArrayAndReassign, rhs: Fuzzilli_Protobuf_DestructArrayAndReassign) -> Bool {
     if lhs.indices != rhs.indices {return false}
+    if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_DestructObject: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DestructObject"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "properties"),
+    2: .same(proto: "hasRestElement"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.properties) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasRestElement_p) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.properties.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.properties, fieldNumber: 1)
+    }
+    if self.hasRestElement_p != false {
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_DestructObject, rhs: Fuzzilli_Protobuf_DestructObject) -> Bool {
+    if lhs.properties != rhs.properties {return false}
+    if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_DestructObjectAndReassign: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DestructObjectAndReassign"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "properties"),
+    2: .same(proto: "hasRestElement"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.properties) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasRestElement_p) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.properties.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.properties, fieldNumber: 1)
+    }
+    if self.hasRestElement_p != false {
+      try visitor.visitSingularBoolField(value: self.hasRestElement_p, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_DestructObjectAndReassign, rhs: Fuzzilli_Protobuf_DestructObjectAndReassign) -> Bool {
+    if lhs.properties != rhs.properties {return false}
     if lhs.hasRestElement_p != rhs.hasRestElement_p {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -266,6 +266,16 @@ message DestructArrayAndReassign {
     bool hasRestElement = 2;
 }
 
+message DestructObject {
+    repeated string properties = 1;
+    bool hasRestElement = 2;
+}
+
+message DestructObjectAndReassign {
+    repeated string properties = 1;
+    bool hasRestElement = 2;
+}
+
 enum Comparator {
     EQUAL = 0;
     STRICT_EQUAL = 1;

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -609,6 +609,22 @@ public struct Fuzzilli_Protobuf_Instruction {
     set {operation = .destructArrayAndReassign(newValue)}
   }
 
+  public var destructObject: Fuzzilli_Protobuf_DestructObject {
+    get {
+      if case .destructObject(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_DestructObject()
+    }
+    set {operation = .destructObject(newValue)}
+  }
+
+  public var destructObjectAndReassign: Fuzzilli_Protobuf_DestructObjectAndReassign {
+    get {
+      if case .destructObjectAndReassign(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_DestructObjectAndReassign()
+    }
+    set {operation = .destructObjectAndReassign(newValue)}
+  }
+
   public var compare: Fuzzilli_Protobuf_Compare {
     get {
       if case .compare(let v)? = operation {return v}
@@ -1032,6 +1048,8 @@ public struct Fuzzilli_Protobuf_Instruction {
     case reassign(Fuzzilli_Protobuf_Reassign)
     case destructArray(Fuzzilli_Protobuf_DestructArray)
     case destructArrayAndReassign(Fuzzilli_Protobuf_DestructArrayAndReassign)
+    case destructObject(Fuzzilli_Protobuf_DestructObject)
+    case destructObjectAndReassign(Fuzzilli_Protobuf_DestructObjectAndReassign)
     case compare(Fuzzilli_Protobuf_Compare)
     case conditionalOperation(Fuzzilli_Protobuf_ConditionalOperation)
     case eval(Fuzzilli_Protobuf_Eval)
@@ -1318,6 +1336,14 @@ public struct Fuzzilli_Protobuf_Instruction {
       }()
       case (.destructArrayAndReassign, .destructArrayAndReassign): return {
         guard case .destructArrayAndReassign(let l) = lhs, case .destructArrayAndReassign(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.destructObject, .destructObject): return {
+        guard case .destructObject(let l) = lhs, case .destructObject(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.destructObjectAndReassign, .destructObjectAndReassign): return {
+        guard case .destructObjectAndReassign(let l) = lhs, case .destructObjectAndReassign(let r) = rhs else { preconditionFailure() }
         return l == r
       }()
       case (.compare, .compare): return {
@@ -1673,6 +1699,8 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     38: .same(proto: "reassign"),
     116: .same(proto: "destructArray"),
     117: .same(proto: "destructArrayAndReassign"),
+    118: .same(proto: "destructObject"),
+    119: .same(proto: "destructObjectAndReassign"),
     39: .same(proto: "compare"),
     96: .same(proto: "conditionalOperation"),
     40: .same(proto: "eval"),
@@ -3074,6 +3102,32 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           self.operation = .destructArrayAndReassign(v)
         }
       }()
+      case 118: try {
+        var v: Fuzzilli_Protobuf_DestructObject?
+        var hadOneofValue = false
+        if let current = self.operation {
+          hadOneofValue = true
+          if case .destructObject(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.operation = .destructObject(v)
+        }
+      }()
+      case 119: try {
+        var v: Fuzzilli_Protobuf_DestructObjectAndReassign?
+        var hadOneofValue = false
+        if let current = self.operation {
+          hadOneofValue = true
+          if case .destructObjectAndReassign(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.operation = .destructObjectAndReassign(v)
+        }
+      }()
       default: break
       }
     }
@@ -3503,6 +3557,14 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .destructArrayAndReassign?: try {
       guard case .destructArrayAndReassign(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 117)
+    }()
+    case .destructObject?: try {
+      guard case .destructObject(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 118)
+    }()
+    case .destructObjectAndReassign?: try {
+      guard case .destructObjectAndReassign(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 119)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -84,6 +84,8 @@ message Instruction {
         Reassign reassign = 38;
         DestructArray destructArray = 116;
         DestructArrayAndReassign destructArrayAndReassign = 117;
+        DestructObject destructObject = 118;
+        DestructObjectAndReassign destructObjectAndReassign = 119;
         Compare compare = 39;
         ConditionalOperation conditionalOperation = 96;
         Eval eval = 40;

--- a/Sources/FuzzilliCli/CodeGeneratorWeights.swift
+++ b/Sources/FuzzilliCli/CodeGeneratorWeights.swift
@@ -72,6 +72,8 @@ let codeGeneratorWeights = [
     "ReassignmentGenerator":                    25,
     "DestructArrayGenerator":                   7,
     "DestructArrayAndReassignGenerator":        7,
+    "DestructObjectGenerator":                  7,
+    "DestructObjectAndReassignGenerator":       7,
     "WithStatementGenerator":                   5,
     "LoadFromScopeGenerator":                   4,
     "StoreToScopeGenerator":                    4,

--- a/Tests/FuzzilliTests/InterpreterTest.swift
+++ b/Tests/FuzzilliTests/InterpreterTest.swift
@@ -724,6 +724,29 @@ class AbstractInterpreterTests: XCTestCase {
         XCTAssertEqual(b.type(of: v6), .integer)
         XCTAssertEqual(b.type(of: v7), .string)
     }
+
+    func testDestructObjectTypeTracking() {
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let intVar = b.loadInt(42)
+        let obj = b.createObject(with: ["foo": intVar])
+        b.setType(ofProperty: "foo", to: .integer)
+        XCTAssertEqual(b.type(of: obj), .object(withProperties: ["foo"]))
+
+        b.storeProperty(b.loadString("Hello"), as: "bar", on: obj)
+        b.setType(ofProperty: "bar", to: .string)
+        XCTAssertEqual(b.type(of: obj), .object(withProperties: ["foo", "bar"]))
+
+        b.storeProperty(intVar, as: "baz", on: obj)
+        b.setType(ofProperty: "baz", to: .integer)
+        XCTAssertEqual(b.type(of: obj), .object(withProperties: ["foo", "bar", "baz"]))
+
+        let outputs = b.destruct(obj, selecting: ["foo", "bar"], hasRestElement: true)
+        XCTAssertEqual(b.type(of: outputs[0]), .integer)
+        XCTAssertEqual(b.type(of: outputs[1]), .string)
+        XCTAssertEqual(b.type(of: outputs[2]), .object())
+    }
 }
 
 extension AbstractInterpreterTests {
@@ -749,6 +772,7 @@ extension AbstractInterpreterTests {
             ("testSuperBinding", testSuperBinding),
             ("testBigintTypeTracking", testBigintTypeTracking),
             ("testSwitchStatementHandling",testSwitchStatementHandling),
+            ("testDestructObjectTypeTracking", testDestructObjectTypeTracking),
         ]
     }
 }

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -116,7 +116,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(fuzzer.lifter.lift(b.finalize()), expectedCode)
     }
 
-    func testNestedCodeStrings(){
+    func testNestedCodeStrings() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -182,7 +182,7 @@ class LifterTests: XCTestCase {
 
     }
 
-    func testConsecutiveNestedCodeStrings(){
+    func testConsecutiveNestedCodeStrings() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -277,7 +277,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program, expected_program)
     }
 
-    func testBlockStatements(){
+    func testBlockStatements() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -316,7 +316,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testAsyncGeneratorLifting(){
+    func testAsyncGeneratorLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -370,7 +370,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testHoleyArrayLifting(){
+    func testHoleyArrayLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -408,7 +408,7 @@ class LifterTests: XCTestCase {
 
     }
 
-    func testTryCatchFinallyLifting(){
+    func testTryCatchFinallyLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -453,7 +453,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testTryCatchLifting(){
+    func testTryCatchLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -490,7 +490,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testTryFinallyLifting(){
+    func testTryFinallyLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -527,7 +527,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testComputedMethodLifting(){
+    func testComputedMethodLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -550,7 +550,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testConditionalOperationLifting(){
+    func testConditionalOperationLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -573,7 +573,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testSwitchStatementLifting(){
+    func testSwitchStatementLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -623,7 +623,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testBinaryOperationReassignLifting(){
+    func testBinaryOperationReassignLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -688,7 +688,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testCreateTemplateLifting(){
+    func testCreateTemplateLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -715,7 +715,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testDeleteOpsLifting(){
+    func testDeleteOpsLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -747,7 +747,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
     
-    func testStrictFunctionLifting(){
+    func testStrictFunctionLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -804,7 +804,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testRegExpInline(){
+    func testRegExpInline() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -828,7 +828,7 @@ class LifterTests: XCTestCase {
     }
 
     
-    func testCallMethodWithSpreadLifting(){
+    func testCallMethodWithSpreadLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -859,7 +859,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testCallComputedMethodWithSpreadLifting(){
+    func testCallComputedMethodWithSpreadLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -892,7 +892,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testConstructWithSpreadLifting(){
+    func testConstructWithSpreadLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -919,7 +919,7 @@ class LifterTests: XCTestCase {
         XCTAssertEqual(lifted_program,expected_program)
     }
 
-    func testCallWithSpreadLifting(){
+    func testCallWithSpreadLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
 
@@ -1131,6 +1131,64 @@ class LifterTests: XCTestCase {
 
         XCTAssertEqual(lifted_program,expected_program)
     }
+
+    func testObjectDestructLifting() {
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let v0 = b.loadInt(42)
+        let v1 = b.loadFloat(13.37)
+        let v2 = b.createObject(with: ["foo": v0, "bar": v1])
+
+        b.destruct(v2, selecting: ["foo"], hasRestElement: true)
+        b.destruct(v2, selecting: ["foo", "bar"], hasRestElement: true)
+        b.destruct(v2, selecting: [String](), hasRestElement: true)
+        b.destruct(v2, selecting: ["foo", "bar"])
+
+        let program = b.finalize()
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        const v2 = {"bar":13.37,"foo":42};
+        let {"foo":v3,...v4} = v2;
+        let {"foo":v5,"bar":v6,...v7} = v2;
+        let {...v8} = v2;
+        let {"foo":v9,"bar":v10,} = v2;
+
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
+
+    func testObjectDestructAndReassignLifting() {
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        let v0 = b.loadInt(42)
+        let v1 = b.loadFloat(13.37)
+        let v2 = b.loadString("Hello")
+        let v3 = b.createObject(with: ["foo": v0, "bar": v1])
+
+        b.destruct(v3, selecting: ["foo"], into: [v2,v0], hasRestElement: true)
+        b.destruct(v3, selecting: ["foo", "bar"], into: [v2,v0,v1], hasRestElement: true)
+        b.destruct(v3, selecting: [String](), into: [v2], hasRestElement: true)
+        b.destruct(v3, selecting: ["foo", "bar"], into: [v2,v1])
+
+        let program = b.finalize()
+        let lifted_program = fuzzer.lifter.lift(program)
+        let expected_program = """
+        let v0 = 42;
+        let v1 = 13.37;
+        let v2 = "Hello";
+        const v3 = {"bar":v1,"foo":v0};
+        ({"foo":v2,...v0} = v3);
+        ({"foo":v2,"bar":v0,...v1} = v3);
+        ({...v2} = v3);
+        ({"foo":v2,"bar":v1,} = v3);
+        
+        """
+
+        XCTAssertEqual(lifted_program,expected_program)
+    }
 }
 
 extension LifterTests {
@@ -1163,9 +1221,11 @@ extension LifterTests {
             ("testCallWithSpreadLifting", testCallWithSpreadLifting),
             ("testPropertyAndElementWithBinopLifting", testPropertyAndElementWithBinopLifting),
             ("testSuperPropertyWithBinopLifting", testSuperPropertyWithBinopLifting),
-            ("testArrayDestructLifting",testArrayDestructLifting),
+            ("testArrayDestructLifting", testArrayDestructLifting),
             ("testArrayDestructAndReassignLifting", testArrayDestructAndReassignLifting),
             ("testForLoopWithArrayDestructLifting", testForLoopWithArrayDestructLifting),
+            ("testObjectDestructLifting", testObjectDestructLifting),
+            ("testArrayDestructAndReassignLifting", testObjectDestructAndReassignLifting),
         ]
     }
 }


### PR DESCRIPTION
This PR adds support for [object destructing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#object_destructuring)