### PR TITLE
ObjectDestructAndReassign can support empty patterns

### DIFF
--- a/Sources/Fuzzilli/FuzzIL/Operations.swift
+++ b/Sources/Fuzzilli/FuzzIL/Operations.swift
@@ -701,7 +701,6 @@ class DestructObjectAndReassign: Operation {
     let hasRestElement: Bool
 
     init(properties: [String], hasRestElement:Bool) {
-        assert(!properties.isEmpty || hasRestElement, "Must have at least one input variable to reassign")
         self.properties = properties
         self.hasRestElement = hasRestElement
         // The first input is the object being destructed


### PR DESCRIPTION
This PR drops an assert statement since object destruct and reassign operations can support empty patterns. Eg:

```js
[] = {foo:10, bar:20}
```