### PR TITLE
Add argument randomization

### DIFF
--- a/Sources/Fuzzilli/Execution/REPRL.swift
+++ b/Sources/Fuzzilli/Execution/REPRL.swift
@@ -22,7 +22,7 @@ public class REPRL: ComponentBase, ScriptRunner {
     private let maxExecsBeforeRespawn = 1000
 
     /// Commandline arguments for the executable
-    private let processArguments: [String]
+    public private(set) var processArguments: [String]
 
     /// Environment variables for the child process
     private var env = [String]()

--- a/Sources/Fuzzilli/Execution/ScriptRunner.swift
+++ b/Sources/Fuzzilli/Execution/ScriptRunner.swift
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 public protocol ScriptRunner: Component {
+    var processArguments: [String] { get }
+
     /// Executes a script, waits for it to complete, and returns the result.
     func run(_ script: String, withTimeout timeout: UInt32) -> Execution
 

--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -646,6 +646,7 @@ public class Fuzzer {
                 program.comments.add("TERMSIG: \(termsig)\n", at: .footer)
                 program.comments.add("STDERR:\n" + stderr, at: .footer)
                 program.comments.add("STDOUT:\n" + stdout, at: .footer)
+                program.comments.add("ARGS: \(runner.processArguments.joined(separator: " "))\n", at: .footer)
             }
             Assert(program.comments.at(.footer)?.contains("CRASH INFO") ?? false)
 

--- a/Sources/Fuzzilli/Util/MockFuzzer.swift
+++ b/Sources/Fuzzilli/Util/MockFuzzer.swift
@@ -25,6 +25,8 @@ struct MockExecution: Execution {
 }
 
 class MockScriptRunner: ScriptRunner {
+    var processArguments: [String] = []
+
     func run(_ script: String, withTimeout timeout: UInt32) -> Execution {
         return MockExecution(outcome: .succeeded,
                              stdout: "",

--- a/Sources/FuzzilliCli/Profiles/DuktapeProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/DuktapeProfile.swift
@@ -15,7 +15,9 @@
 import Fuzzilli
 
 let duktapeProfile = Profile(
-    processArguments: ["--reprl"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        return ["--reprl"]
+    },
 
     processEnv: ["UBSAN_OPTIONS": "handle_segv=0"],
 

--- a/Sources/FuzzilliCli/Profiles/JSCProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/JSCProfile.swift
@@ -31,18 +31,37 @@ fileprivate let ForceFTLCompilationGenerator = CodeGenerator("ForceFTLCompilatio
 }
 
 let jscProfile = Profile(
-    processArguments: ["--validateOptions=true",
-                       // No need to call functions thousands of times before they are JIT compiled
-                       "--thresholdForJITSoon=10",
-                       "--thresholdForJITAfterWarmUp=10",
-                       "--thresholdForOptimizeAfterWarmUp=100",
-                       "--thresholdForOptimizeAfterLongWarmUp=100",
-                       "--thresholdForOptimizeSoon=100",
-                       "--thresholdForFTLOptimizeAfterWarmUp=1000",
-                       "--thresholdForFTLOptimizeSoon=1000",
-                       // Enable bounds check elimination validation
-                       "--validateBCE=true",
-                       "--reprl"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        var args = [
+            "--validateOptions=true",
+            // No need to call functions thousands of times before they are JIT compiled
+            "--thresholdForJITSoon=10",
+            "--thresholdForJITAfterWarmUp=10",
+            "--thresholdForOptimizeAfterWarmUp=100",
+            "--thresholdForOptimizeAfterLongWarmUp=100",
+            "--thresholdForOptimizeSoon=100",
+            "--thresholdForFTLOptimizeAfterWarmUp=1000",
+            "--thresholdForFTLOptimizeSoon=1000",
+            // Enable bounds check elimination validation
+            "--validateBCE=true",
+            "--reprl"]
+
+        guard randomizingArguments else { return args }
+
+        args.append("--useBaselineJIT=\(probability(0.9) ? "true" : "false")")
+        args.append("--useDFGJIT=\(probability(0.9) ? "true" : "false")")
+        args.append("--useFTLJIT=\(probability(0.9) ? "true" : "false")")
+        args.append("--useRegExpJIT=\(probability(0.9) ? "true" : "false")")
+        args.append("--useTailCalls=\(probability(0.9) ? "true" : "false")")
+        args.append("--optimizeRecursiveTailCalls=\(probability(0.9) ? "true" : "false")")
+        args.append("--useObjectAllocationSinking=\(probability(0.9) ? "true" : "false")")
+        args.append("--useArityFixupInlining=\(probability(0.9) ? "true" : "false")")
+        args.append("--useValueRepElimination=\(probability(0.9) ? "true" : "false")")
+        args.append("--useArchitectureSpecificOptimizations=\(probability(0.9) ? "true" : "false")")
+        args.append("--useAccessInlining=\(probability(0.9) ? "true" : "false")")
+
+        return args
+    },
 
     processEnv: ["UBSAN_OPTIONS":"handle_segv=0"],
 

--- a/Sources/FuzzilliCli/Profiles/JerryscriptProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/JerryscriptProfile.swift
@@ -15,7 +15,9 @@
 import Fuzzilli
 
 let jerryscriptProfile = Profile(
-    processArguments: ["--reprl-fuzzilli"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        return ["--reprl-fuzzilli"]
+    },
 
     // processEnv: [:],
     processEnv: ["UBSAN_OPTIONS":"handle_segv=0"],

--- a/Sources/FuzzilliCli/Profiles/Profile.swift
+++ b/Sources/FuzzilliCli/Profiles/Profile.swift
@@ -15,7 +15,7 @@
 import Fuzzilli
 
 struct Profile {
-    let processArguments: [String]
+    let getProcessArguments: (_: Bool) -> [String]
     let processEnv: [String : String]
     let codePrefix: String
     let codeSuffix: String

--- a/Sources/FuzzilliCli/Profiles/QjsProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/QjsProfile.swift
@@ -15,7 +15,9 @@
 import Fuzzilli
 
 let qjsProfile = Profile(
-    processArguments: ["--reprl"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        return ["--reprl"]
+    },
 
     processEnv: ["UBSAN_OPTIONS": "handle_segv=0"],
 

--- a/Sources/FuzzilliCli/Profiles/QtjsProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/QtjsProfile.swift
@@ -25,7 +25,10 @@ fileprivate let ForceQV4JITGenerator = CodeGenerator("ForceQV4JITGenerator", inp
 }
 
 let qtjsProfile = Profile(
-    processArguments: ["-reprl"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        return ["-reprl"]
+    },
+
     processEnv: ["UBSAN_OPTIONS":"handle_segv=0"],
 
     codePrefix: """

--- a/Sources/FuzzilliCli/Profiles/V8Profile.swift
+++ b/Sources/FuzzilliCli/Profiles/V8Profile.swift
@@ -231,14 +231,45 @@ fileprivate let VerifyTypeTemplate = ProgramTemplate("VerifyTypeTemplate") { b i
 }
 
 let v8Profile = Profile(
-    processArguments: ["--expose-gc",
-                       "--future",
-                       "--harmony",
-                       "--assert-types",
-                       "--harmony-rab-gsab",
-                       "--allow-natives-syntax",
-                       "--interrupt-budget=1024",
-                       "--fuzzing"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        var args = [
+            "--expose-gc",
+            "--future",
+            "--harmony",
+            "--assert-types",
+            "--harmony-rab-gsab",
+            "--allow-natives-syntax",
+            "--interrupt-budget=1024",
+            "--fuzzing"]
+
+        guard randomizingArguments else { return args }
+
+        args.append(probability(0.9) ? "--sparkplug" : "--no-sparkplug")
+        args.append(probability(0.9) ? "--opt" : "--no-opt")
+        args.append(probability(0.9) ? "--lazy" : "--no-lazy")
+        args.append(probability(0.1) ? "--always-opt" : "--no-always-opt")
+        args.append(probability(0.1) ? "--always-osr" : "--no-always-osr")
+        args.append(probability(0.1) ? "--force-slow-path" : "--no-force-slow-path")
+        args.append(probability(0.9) ? "--turbo-move-optimization" : "--no-turbo-move-optimization")
+        args.append(probability(0.9) ? "--turbo-jt" : "--no-turbo-jt")
+        args.append(probability(0.9) ? "--turbo-loop-peeling" : "--no-turbo-loop-peeling")
+        args.append(probability(0.9) ? "--turbo-loop-variable" : "--no-turbo-loop-variable")
+        args.append(probability(0.9) ? "--turbo-loop-rotation" : "--no-turbo-loop-rotation")
+        args.append(probability(0.9) ? "--turbo-cf-optimization" : "--no-turbo-cf-optimization")
+        args.append(probability(0.9) ? "--turbo-escape" : "--no-turbo-escape")
+        args.append(probability(0.9) ? "--turbo-allocation-folding" : "--no-turbo-allocation-folding")
+        args.append(probability(0.9) ? "--turbo-instruction-scheduling" : "--no-turbo-instruction-scheduling")
+        args.append(probability(0.9) ? "--turbo-stress-instruction-scheduling" : "--no-turbo-stress-instruction-scheduling")
+        args.append(probability(0.9) ? "--turbo-store-elimination" : "--no-turbo-store-elimination")
+        args.append(probability(0.9) ? "--turbo-rewrite-far-jumps" : "--no-turbo-rewrite-far-jumps")
+        args.append(probability(0.9) ? "--turbo-optimize-apply" : "--no-turbo-optimize-apply")
+        args.append(chooseUniform(from: ["--no-enable-sse3", "--no-enable-ssse3", "--no-enable-sse4-1", "--no-enable-sse4-2", "--no-enable-avx", "--no-enable-avx2",]))
+        args.append(probability(0.9) ? "--turbo-load-elimination" : "--no-turbo-load-elimination")
+        args.append(probability(0.9) ? "--turbo-inlining" : "--no-turbo-inlining")
+        args.append(probability(0.9) ? "--turbo-splitting" : "--no-turbo-splitting")
+
+        return args
+    },
 
     processEnv: [:],
 

--- a/Sources/FuzzilliCli/Profiles/XSProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/XSProfile.swift
@@ -15,7 +15,9 @@
 import Fuzzilli
 
 let xsProfile = Profile(
-    processArguments: ["-f"],
+    getProcessArguments: { (randomizingArguments: Bool) -> [String] in
+        return ["-f"]
+    },
 
     processEnv: ["UBSAN_OPTIONS":"handle_segv=0"],
 

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -107,6 +107,7 @@ Options:
                                          types: Programs written to disk also contain variable type information as
                                                 determined by Fuzzilli as comments
                                            all: All of the above
+    --argumentRandomization      : Enable JS engine argument randomization
 """)
     exit(0)
 }
@@ -163,6 +164,7 @@ let collectRuntimeTypes = args.has("--collectRuntimeTypes")
 let diagnostics = args.has("--diagnostics")
 let inspect = args["--inspect"]
 let swarmTesting = args.has("--swarmTesting")
+let randomizingArguments = args.has("--argumentRandomization")
 
 guard numJobs >= 1 else {
     configError("Must have at least 1 job")
@@ -365,7 +367,7 @@ for (generator, var weight) in (additionalCodeGenerators + regularCodeGenerators
 
 func makeFuzzer(for profile: Profile, with configuration: Configuration) -> Fuzzer {
     // A script runner to execute JavaScript code in an instrumented JS engine.
-    let runner = REPRL(executable: jsShellPath, processArguments: profile.processArguments, processEnvironment: profile.processEnv)
+    let runner = REPRL(executable: jsShellPath, processArguments: profile.getProcessArguments(randomizingArguments), processEnvironment: profile.processEnv)
 
     let engine: FuzzEngine
     switch engineName {


### PR DESCRIPTION
This PR adds support for randomizing the command line arguments of the js engines.
The command line of fuzzilli now takes an additional optional argument `--argumentRandomization=` which is either `none` (default), `initial` (the instances to randomize the arguments once when starting fuzzilli) or `periodic` (periodic re-randomization of command line arguments).
Currently, randomization is supported for v8, spidermonkey and jsc only. Adding support for randomizing command line args of additional engines should be relatively straightforwards.

Any feedback on the PR is welcome, its plenty of changes.