### PR TITLE
Add `--statisticsExportInterval option` for specifying interval for saving fuzzing stats to disk

### DIFF
--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -26,73 +26,73 @@ Usage:
 \(args.programName) [options] --profile=<profile> /path/to/jsshell
 
 Options:
-    --profile=name              : Select one of several preconfigured profiles.
-                                  Available profiles: \(profiles.keys).
-    --jobs=n                    : Total number of fuzzing jobs. This will start one master thread and n-1 worker threads.
-    --engine=name               : The fuzzing engine to use. Available engines: "mutation" (default), "hybrid", "multi".
-                                  Only the mutation engine should be regarded stable at this point.
-    --corpus=name               : The corpus scheduler to use. Available schedulers: "basic" (default), "markov"
-    --minDeterminismExecs=n     : The minimum number of times a new sample will be executed when checking determinism (default: 3)
-    --maxDeterminismExecs=n     : The maximum number of times a new sample will be executed when checking determinism (default: 50)
-    --noDeterministicCorpus     : Don't ensure that samples added to the corpus behave deterministically.
-    --maxResetCount=n           : The number of times a non-deterministic edge is reset before it is ignored in subsequent executions.
-                                  Only used as part of --deterministicCorpus.
-    --logLevel=level            : The log level to use. Valid values: "verbose", info", "warning", "error", "fatal"
-                                  (default: "info").
-    --numIterations=n           : Run for the specified number of iterations (default: unlimited).
-    --timeout=n                 : Timeout in ms after which to interrupt execution of programs (default: 250).
-    --minMutationsPerSample=n   : Discard samples from the corpus only after they have been mutated at least this many times (default: 100).
-    --minCorpusSize=n           : Keep at least this many samples in the corpus regardless of the number of times
-                                  they have been mutated (default: 1024).
-    --maxCorpusSize=n           : Only allow the corpus to grow to this many samples. Otherwise the oldest samples
-                                  will be discarded (default: unlimited).
-    --markovDropoutRate=p       : Rate at which low edge samples are not selected, in the Markov Corpus Scheduler,
-                                  per round of sample selection. Used to ensure diversity between fuzzer instances
-                                  (default: 0.10)
-    --consecutiveMutations=n    : Perform this many consecutive mutations on each sample (default: 5).
-    --minimizationLimit=p       : When minimizing interesting programs, keep at least this percentage of the original instructions
-                                  regardless of whether they are needed to trigger the interesting behaviour or not.
-                                  See Minimizer.swift for an overview of this feature (default: 0.0).
-    --storagePath=path          : Path at which to store output files (crashes, corpus, etc.) to.
-    --resume                    : If storage path exists, import the programs from the corpus/ subdirectory
-    --overwrite                 : If storage path exists, delete all data in it and start a fresh fuzzing session
-    --exportStatistics          : If enabled, fuzzing statistics will be collected and saved to disk in regular intervals.
-                                  Requires --storagePath.
+    --profile=name               : Select one of several preconfigured profiles.
+                                   Available profiles: \(profiles.keys).
+    --jobs=n                     : Total number of fuzzing jobs. This will start one master thread and n-1 worker threads.
+    --engine=name                : The fuzzing engine to use. Available engines: "mutation" (default), "hybrid", "multi".
+                                   Only the mutation engine should be regarded stable at this point.
+    --corpus=name                : The corpus scheduler to use. Available schedulers: "basic" (default), "markov"
+    --minDeterminismExecs=n      : The minimum number of times a new sample will be executed when checking determinism (default: 3)
+    --maxDeterminismExecs=n      : The maximum number of times a new sample will be executed when checking determinism (default: 50)
+    --noDeterministicCorpus      : Don't ensure that samples added to the corpus behave deterministically.
+    --maxResetCount=n            : The number of times a non-deterministic edge is reset before it is ignored in subsequent executions.
+                                   Only used as part of --deterministicCorpus.
+    --logLevel=level             : The log level to use. Valid values: "verbose", info", "warning", "error", "fatal"
+                                   (default: "info").
+    --numIterations=n            : Run for the specified number of iterations (default: unlimited).
+    --timeout=n                  : Timeout in ms after which to interrupt execution of programs (default: 250).
+    --minMutationsPerSample=n    : Discard samples from the corpus only after they have been mutated at least this many times (default: 100).
+    --minCorpusSize=n            : Keep at least this many samples in the corpus regardless of the number of times
+                                   they have been mutated (default: 1024).
+    --maxCorpusSize=n            : Only allow the corpus to grow to this many samples. Otherwise the oldest samples
+                                   will be discarded (default: unlimited).
+    --markovDropoutRate=p        : Rate at which low edge samples are not selected, in the Markov Corpus Scheduler,
+                                   per round of sample selection. Used to ensure diversity between fuzzer instances
+                                   (default: 0.10)
+    --consecutiveMutations=n     : Perform this many consecutive mutations on each sample (default: 5).
+    --minimizationLimit=p        : When minimizing interesting programs, keep at least this percentage of the original instructions
+                                   regardless of whether they are needed to trigger the interesting behaviour or not.
+                                   See Minimizer.swift for an overview of this feature (default: 0.0).
+    --storagePath=path           : Path at which to store output files (crashes, corpus, etc.) to.
+    --resume                     : If storage path exists, import the programs from the corpus/ subdirectory
+    --overwrite                  : If storage path exists, delete all data in it and start a fresh fuzzing session
+    --exportStatistics           : If enabled, fuzzing statistics will be collected and saved to disk in regular intervals.
+                                   Requires --storagePath.
     --statisticsExportInterval=n : Interval in minutes for saving fuzzing statistics to disk (default: 10).
                                    Requires --exportStatistics.
-    --importCorpusAll=path      : Imports a corpus of protobufs to start the initial fuzzing corpus.
-                                  All provided programs are included, even if they do not increase coverage.
-                                  This is useful for searching for variants of existing bugs.
-                                  Can be used alongside with importCorpusNewCov, and will run first
-    --importCorpusNewCov=path   : Imports a corpus of protobufs to start the initial fuzzing corpus.
-                                  This only includes programs that increase coverage.
-                                  This is useful for jump starting coverage for a wide range of JavaScript samples.
-                                  Can be used alongside importCorpusAll, and will run second.
-                                  Since all imported samples are asynchronously minimized, the corpus will show a smaller
-                                  than expected size until minimization completes.
-    --importCorpusMerge=path    : Imports a corpus of protobufs to start the initial fuzzing corpus.
-                                  This only keeps programs that increase coverage but does not attempt to minimize
-                                  the samples. This is mostly useful to merge existing corpora from previous fuzzing
-                                  sessions that will have redundant samples but which will already be minimized.
-    --networkMaster=host:port   : Run as master and accept connections from workers over the network. Note: it is
-                                  *highly* recommended to run network fuzzers in an isolated network!
-    --networkWorker=host:port   : Run as worker and connect to the specified master instance.
-    --noCorpusSynchronization   : Do not synchronize the corpus between instances. This way, the workers will behave
-                                  like separate instances (and may therefore stress different parts of the target),
-                                  but crashes will still be collected at one central location.
-    --dontFuzz                  : If used, this instance will not perform fuzzing. Can be useful for master instances.
-    --noAbstractInterpretation  : Disable abstract interpretation of FuzzIL programs during fuzzing. See
-                                  Configuration.swift for more details.
-    --collectRuntimeTypes       : Collect runtime type information for programs that are added to the corpus.
-    --diagnostics               : Enable saving of programs that failed or timed-out during execution. Also tracks
-                                  executions on the current REPRL instance.
-    --inspect=opt1,opt2,...     : Enable inspection options. The following options are available:
-                                      history: Additional .fuzzil.history files are written to disk for every program.
-                                               These describe in detail how the program was generated through mutations,
-                                               code generation, and minimization
-                                        types: Programs written to disk also contain variable type information as
-                                               determined by Fuzzilli as comments
-                                          all: All of the above
+    --importCorpusAll=path       : Imports a corpus of protobufs to start the initial fuzzing corpus.
+                                   All provided programs are included, even if they do not increase coverage.
+                                   This is useful for searching for variants of existing bugs.
+                                   Can be used alongside with importCorpusNewCov, and will run first
+    --importCorpusNewCov=path    : Imports a corpus of protobufs to start the initial fuzzing corpus.
+                                   This only includes programs that increase coverage.
+                                   This is useful for jump starting coverage for a wide range of JavaScript samples.
+                                   Can be used alongside importCorpusAll, and will run second.
+                                   Since all imported samples are asynchronously minimized, the corpus will show a smaller
+                                   than expected size until minimization completes.
+    --importCorpusMerge=path     : Imports a corpus of protobufs to start the initial fuzzing corpus.
+                                   This only keeps programs that increase coverage but does not attempt to minimize
+                                   the samples. This is mostly useful to merge existing corpora from previous fuzzing
+                                   sessions that will have redundant samples but which will already be minimized.
+    --networkMaster=host:port    : Run as master and accept connections from workers over the network. Note: it is
+                                   *highly* recommended to run network fuzzers in an isolated network!
+    --networkWorker=host:port    : Run as worker and connect to the specified master instance.
+    --noCorpusSynchronization    : Do not synchronize the corpus between instances. This way, the workers will behave
+                                   like separate instances (and may therefore stress different parts of the target),
+                                   but crashes will still be collected at one central location.
+    --dontFuzz                   : If used, this instance will not perform fuzzing. Can be useful for master instances.
+    --noAbstractInterpretation   : Disable abstract interpretation of FuzzIL programs during fuzzing. See
+                                   Configuration.swift for more details.
+    --collectRuntimeTypes        : Collect runtime type information for programs that are added to the corpus.
+    --diagnostics                : Enable saving of programs that failed or timed-out during execution. Also tracks
+                                   executions on the current REPRL instance.
+    --inspect=opt1,opt2,...      : Enable inspection options. The following options are available:
+                                       history: Additional .fuzzil.history files are written to disk for every program.
+                                                These describe in detail how the program was generated through mutations,
+                                                code generation, and minimization
+                                         types: Programs written to disk also contain variable type information as
+                                                determined by Fuzzilli as comments
+                                           all: All of the above
 """)
     exit(0)
 }

--- a/Sources/FuzzilliCli/main.swift
+++ b/Sources/FuzzilliCli/main.swift
@@ -61,7 +61,7 @@ Options:
     --importCorpusAll=path      : Imports a corpus of protobufs to start the initial fuzzing corpus.
                                   All provided programs are included, even if they do not increase coverage.
                                   This is useful for searching for variants of existing bugs.
-                                  Can be used alongside wtih importCorpusNewCov, and will run first
+                                  Can be used alongside with importCorpusNewCov, and will run first
     --importCorpusNewCov=path   : Imports a corpus of protobufs to start the initial fuzzing corpus.
                                   This only includes programs that increase coverage.
                                   This is useful for jump starting coverage for a wide range of JavaScript samples.
@@ -78,7 +78,7 @@ Options:
     --noCorpusSynchronization   : Do not synchronize the corpus between instances. This way, the workers will behave
                                   like separate instances (and may therefore stress different parts of the target),
                                   but crashes will still be collected at one central location.
-    --dontFuzz                  : If used, this instace will not perform fuzzing. Can be useful for master instances.
+    --dontFuzz                  : If used, this instance will not perform fuzzing. Can be useful for master instances.
     --noAbstractInterpretation  : Disable abstract interpretation of FuzzIL programs during fuzzing. See
                                   Configuration.swift for more details.
     --collectRuntimeTypes       : Collect runtime type information for programs that are added to the corpus.
@@ -431,7 +431,7 @@ fuzzer.sync {
             logger.info("Deleting all files in \(path) due to --overwrite")
             try? FileManager.default.removeItem(atPath: path)
         } else {
-            // The corpus directory mus be empty. We already checked this above, so just assert here
+            // The corpus directory must be empty. We already checked this above, so just assert here
             let directory = (try? FileManager.default.contentsOfDirectory(atPath: path + "/corpus")) ?? []
             assert(directory.isEmpty)
         }


### PR DESCRIPTION
### Test Plan
I ran the following commands, we expect Fuzzilli to begin fuzzing:
- `swift run -c release FuzzilliCli --profile=v8 --storagePath=./test --exportStatistics d8` to test that `--statisticsExportInterval` is an optional parameter

- `swift run -c release FuzzilliCli --profile=v8 --storagePath=./test --exportStatistics --statisticsExportInterval=1 d8` and let it run for 1 minute, then stopped Fuzzilli and checked if `./test/stats` contains a single json file

I ran the following commands to check for invalid options:

- `swift run -c release FuzzilliCli --profile=v8 --storagePath=./test --statisticsExportInterval=1 d8` will print `statisticsExportInterval requires --exportStatistics` 

- `swift run -c release FuzzilliCli --profile=v8 --storagePath=./test --exportStatistics --statisticsExportInterval=0 d8` will print `statisticsExportInterval needs to be > 0`

