### PR TITLE
Add customizable channels to REPRL

### DIFF
--- a/Sources/REPRLRun/main.swift
+++ b/Sources/REPRLRun/main.swift
@@ -38,9 +38,11 @@ if ctx == nil {
 
 let argv = convertToCArray(Array(CommandLine.arguments[1...]))
 let envp = convertToCArray([])
-if reprl_initialize_context(ctx, argv, envp, /* capture_stdout: */ 1, /* capture stderr: */ 1) != 0 {
+if reprl_initialize_context(ctx, argv, envp) != 0 {
     print("Failed to initialize REPRL context: \(String(cString: reprl_get_last_error(ctx)))")
 }
+reprl_create_additional_channel(ctx, 1); // capture stdout
+reprl_create_additional_channel(ctx, 2); // capture stderr
 
 func execute(_ code: String) -> (status: Int32, exec_time: UInt64) {
     var exec_time: UInt64 = 0
@@ -119,6 +121,6 @@ while true {
 
     print("Execution finished with status \(status) (signaled: \(RIFSIGNALED(status) != 0), timed out: \(RIFTIMEDOUT(status) != 0)) and took \(exec_time / 1000)ms")
     print("========== Fuzzout ==========\n\(String(cString: reprl_fetch_fuzzout(ctx)))")
-    print("========== Stdout ==========\n\(String(cString: reprl_fetch_stdout(ctx)))")
-    print("========== Stderr ==========\n\(String(cString: reprl_fetch_stderr(ctx)))")
+    print("========== Stdout ==========\n\(String(cString: reprl_fetch_channel(ctx, 1)))")
+    print("========== Stderr ==========\n\(String(cString: reprl_fetch_channel(ctx, 2)))")
 }

--- a/Sources/libreprl/include/libreprl.h
+++ b/Sources/libreprl/include/libreprl.h
@@ -24,6 +24,8 @@
 /// Opaque struct representing a REPRL execution context.
 struct reprl_context;
 
+int reprl_create_additional_channel(struct reprl_context* ctx, int fd);
+
 /// Allocates a new REPRL context.
 /// @return an uninitialzed REPRL context
 struct reprl_context* reprl_create_context();
@@ -32,10 +34,8 @@ struct reprl_context* reprl_create_context();
 /// @param ctx An uninitialized context
 /// @param argv The argv vector for the child processes
 /// @param envp The envp vector for the child processes
-/// @param capture_stdout Whether this REPRL context should capture the child's stdout
-/// @param capture_stderr Whether this REPRL context should capture the child's stderr
 /// @return zero in case of no errors, otherwise a negative value
-int reprl_initialize_context(struct reprl_context* ctx, const char** argv, const char** envp, int capture_stdout, int capture_stderr);
+int reprl_initialize_context(struct reprl_context* ctx, const char** argv, const char** envp);
 
 /// Destroys a REPRL context, freeing all resources held by it.
 /// @param ctx The context to destroy
@@ -87,23 +87,18 @@ static inline int REXITSTATUS(int status)
     return (status >> 8) & 0xff;
 }
 
-/// Returns the stdout data of the last successful execution if the context is capturing stdout, otherwise an empty string.
-/// The output is limited to REPRL_MAX_FAST_IO_SIZE (currently 16MB).
-/// @param ctx The REPRL context
-/// @return A string pointer which is owned by the REPRL context and thus should not be freed by the caller
-const char* reprl_fetch_stdout(struct reprl_context* ctx);
-
-/// Returns the stderr data of the last successful execution if the context is capturing stderr, otherwise an empty string.
-/// The output is limited to REPRL_MAX_FAST_IO_SIZE (currently 16MB).
-/// @param ctx The REPRL context
-/// @return A string pointer which is owned by the REPRL context and thus should not be freed by the caller
-const char* reprl_fetch_stderr(struct reprl_context* ctx);
-
 /// Returns the fuzzout data of the last successful execution.
 /// The output is limited to REPRL_MAX_FAST_IO_SIZE (currently 16MB).
 /// @param ctx The REPRL context
 /// @return A string pointer which is owned by the REPRL context and thus should not be freed by the caller
 const char* reprl_fetch_fuzzout(struct reprl_context* ctx);
+
+/// Returns the runtime data of the last successful execution.
+/// The output is limited to REPRL_MAX_FAST_IO_SIZE (currently 16MB).
+/// @param ctx The REPRL context
+/// @param fd  The file descripter
+/// @return A string pointer which is owned by the REPRL context and thus should not be freed by the caller
+const char* reprl_fetch_channel(struct reprl_context* ctx, int fd);
 
 /// Returns a string describing the last error that occurred in the given context.
 /// @param ctx The REPRL context

--- a/Sources/libreprl/libreprl-posix.c
+++ b/Sources/libreprl/libreprl-posix.c
@@ -45,7 +45,7 @@
 
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
-#define MAX_ADDITIONAL_CHANNEL 100
+#define MAX_ADDITIONAL_CHANNEL 10
 
 static uint64_t current_usecs()
 {
@@ -188,6 +188,10 @@ int reprl_create_additional_channel(struct reprl_context* ctx, int fd) {
             break;
         }
         if (ctx->child_channels[i]->desired_fd == fd) {
+            return -1;
+        }
+        // No slots available
+        if (i == MAX_ADDITIONAL_CHANNEL -1) {
             return -1;
         }
     }
@@ -379,6 +383,7 @@ int reprl_initialize_context(struct reprl_context* ctx, const char** argv, const
         // Proper error message will have been set by reprl_create_data_channel
         return -1;
     }
+    memset(ctx->child_channels, 0, sizeof(ctx->child_channels));
     
     ctx->initialized = 1;
     return 0;


### PR DESCRIPTION
Currently, Fuzzilli uses REPRLExecution (stdout, stderr, and fuzzout) to receive JS runtime output. However, in order for a researcher to create an independent data channel for receiving additional runtime output, the following operations are required.
1) Create a new data channel by modifying the libreprl code (add `reprl_create_data_channel(ctx)` call and save return value to reprl_context, e.g., [link](https://github.com/googleprojectzero/fuzzilli/blob/17292b1e673b55e3d1383cc155ac3a4427739451/Sources/libreprl/libreprl-posix.c#L313-L318))
2) Add fetch and destroy function call with the additional data channel (`reprl_fetch_xxxx`, `reprl_destroy_data_channel(xxxx)`)
3) Add a function that outputs arguments to a specific data channel (fd) by modifying the JavaScript engine (e.g., `printTo(fd, var)`)
4) Add new variable under REPRLExecution (like stdout, stderr, fuzzout)

These operations must be performed repeatedly whenever a new data channel is needed. To address these issues, I suggest changing some of the libreprl and Fuzzilli REPRL code structures.

What do you think about it?