### PR TITLE
Increase timeout for tests from 5 seconds to 7 minutes

### DIFF
--- a/Tests/FuzzilliTests/LiveTests.swift
+++ b/Tests/FuzzilliTests/LiveTests.swift
@@ -45,7 +45,7 @@ class LiveTests: XCTestCase {
 
             // TODO: consider moving this code into a shared function once other tests need it as well.
             do {
-                let result = try nodejs.executeScript(jsProgram, withTimeout: 5 * Seconds)
+                let result = try nodejs.executeScript(jsProgram, withTimeout: 7 * Minutes)
                 if result.isFailure {
                     failures += 1
 


### PR DESCRIPTION
7 minutes was determined based off latest GitHub Action build job run times below:

https://github.com/googleprojectzero/fuzzilli/actions/runs/5526539379/jobs/10081377259
https://github.com/googleprojectzero/fuzzilli/actions/runs/5526539379/jobs/10081377406
https://github.com/googleprojectzero/fuzzilli/actions/runs/5519167366/jobs/10064079730
https://github.com/googleprojectzero/fuzzilli/actions/runs/5519167366/jobs/10064079510
https://github.com/googleprojectzero/fuzzilli/actions/runs/5519182385/jobs/10064113820
https://github.com/googleprojectzero/fuzzilli/actions/runs/5519182385/jobs/10064114057