### PR TITLE
Profiles/Serenity: Resolve build errors in file

### DIFF
--- a/Sources/FuzzilliCli/Profiles/Serenity.swift
+++ b/Sources/FuzzilliCli/Profiles/Serenity.swift
@@ -15,28 +15,33 @@
 import Fuzzilli
 
 let serenityProfile = Profile(
-    processArguments: [""],
+    processArgs: { randomize in return [""] },
     processEnv: [
-    "UBSAN_OPTIONS":"handle_segv=0 handle_abrt=0",
-    "ASAN_OPTIONS":"abort_on_error=1"
+        "UBSAN_OPTIONS": "handle_segv=0 handle_abrt=0",
+        "ASAN_OPTIONS": "abort_on_error=1",
     ],
     maxExecsBeforeRespawn: 1000,
     timeout: 250,
-    codePrefix: ""
-    codeSuffix: ""
+    codePrefix: """
+                 function main() {
+                 """,
+     codeSuffix: """
+                 }
+                 main();
+                 """,
     ecmaVersion: ECMAScriptVersion.es6,
 
     crashTests: ["fuzzilli('FUZZILLI_CRASH', 0)", "fuzzilli('FUZZILLI_CRASH', 1)"],
 
-    additionalCodeGenerators: WeightedList<CodeGenerator>([]),
+    additionalCodeGenerators: [],
     additionalProgramTemplates: WeightedList<ProgramTemplate>([]),
 
     disabledCodeGenerators: [],
     disabledMutators: [],
 
     additionalBuiltins: [
-        "gc" : .function([] => .undefined)
-    ]
+        "gc": .function([] => .undefined)
+    ],
 
     optionalPostProcessor: nil
 )


### PR DESCRIPTION
Verified to work with current master commit of SerenityOS/serenity.
    
Turns out the code prefix/suffix are required due to the way that the
.cpp file of the SerenityOS Fuzzer binary driver is written.

Resolves build errors from #406 

<details>

<summary> Old runtime error </summary>

@jvoisin how did you test that the FuzziliJS fuzzer target here works with the current Fuzzili main branch? https://github.com/SerenityOS/serenity/blob/107bfbe2830fe9ba18327ed36521d371ff0673db/Meta/Lagom/Fuzzers/FuzzilliJs.cpp 

I ran it on my macOS machine per our older instructions (Meta/Lagom/Fuzzers/FuzzilliJsInstructions.md) like so:

```
# in serenity checkout
cd Meta/Lagom; ./BuildFuzzers.sh
# in fuzzili checkout
swift run -c release FuzzilliCli --profile=serenity /Users/andrew/Source/serenity/Meta/Lagom/Build/lagom-fuzzers/bin/FuzzilliJs `
```
 and it complained about not really running at all:

```
[Cli] Using the following arguments for the target engine: [""]
[Cli] Enabled mutators: ["ExplorationMutator", "CodeGenMutator", "SpliceMutator", "ProbingMutator", "InputMutator", "InputMutator (type aware)", "OperationMutator", "CombineMutator"]
[Cli] No filesystem storage configured, found crashes will be discarded!
[Coverage] Initialized, 611 edges
[JavaScriptEnvironment] Initialized static JS environment model
[JavaScriptEnvironment] Have 52 available builtins: ["parseInt", "Infinity", "Uint32Array", "Function", "AggregateError", "SyntaxError", "TypeError", "RangeError", "Set", "Math", "NaN", "gc", "Float64Array", "SharedArrayBuffer", "undefined", "WeakRef", "eval", "WeakSet", "String", "BigInt64Array", "Int32Array", "Object", "Error", "Uint8Array", "Uint8ClampedArray", "Reflect", "FinalizationRegistry", "URIError", "parseFloat", "Promise", "Symbol", "Int16Array", "Array", "Proxy", "BigUint64Array", "Map", "Boolean", "RegExp", "DataView", "Uint16Array", "Int8Array", "Date", "WeakMap", "ArrayBuffer", "isFinite", "BigInt", "isNaN", "ReferenceError", "Number", "Float32Array", "EvalError", "JSON"]
[JavaScriptEnvironment] Have 51 different object groups: ["ArrayConstructor", "PromiseConstructor", "Uint32Array", "EvalError", "WeakSet", "ReferenceError", "NumberConstructor", "Arguments", "Date", "Int32Array", "Uint8ClampedArray", "Symbol", "Function", "SharedArrayBuffer", "BooleanConstructor", "RegExp", "SyntaxError", "ArrayBufferConstructor", "ArrayBuffer", "Uint8Array", "Int16Array", "Array", "Float64Array", "Float32Array", "JSON", "RangeError", "URIError", "Uint16Array", "String", "Promise", "BigInt64Array", "Map", "SharedArrayBufferConstructor", "AggregateError", "Reflect", "SymbolConstructor", "DateConstructor", "FinalizationRegistry", "StringConstructor", "WeakRef", "TypeError", "ObjectConstructor", "Error", "DataView", "BigUint64Array", "Set", "Generator", "WeakMap", "Int8Array", "BigIntConstructor", "Math"]
[JavaScriptEnvironment] Have 50 builtin property names: ["cause", "isConcatSpreadable", "toPrimitive", "MIN_SAFE_INTEGER", "byteOffset", "__proto__", "PI", "stack", "multiline", "prototype", "NEGATIVE_INFINITY", "caller", "match", "global", "description", "unicode", "size", "dotAll", "flags", "asyncIterator", "POSITIVE_INFINITY", "iterator", "length", "unscopables", "hasInstance", "arguments", "EPSILON", "matchAll", "ignoreCase", "constructor", "species", "callee", "growable", "search", "maxByteLength", "MIN_VALUE", "buffer", "MAX_VALUE", "sticky", "byteLength", "source", "split", "replace", "NaN", "resizable", "toStringTag", "E", "name", "message", "MAX_SAFE_INTEGER"]
[JavaScriptEnvironment] Have 222 builtin method names: ["tanh", "fill", "replaceAll", "search", "toLowerCase", "raw", "filter", "hypot", "log1p", "shift", "indexOf", "at", "setHours", "atan", "toUTCString", "toGMTString", "sinh", "setFullYear", "from", "getInt8", "setUTCMilliseconds", "floor", "sqrt", "getHours", "getTimezoneOffset", "log2", "sort", "clz32", "push", "acosh", "getMilliseconds", "padEnd", "getUint8", "random", "transfer", "fromCodePoint", "trimLeft", "getDate", "atan2", "race", "startsWith", "seal", "clear", "setFloat32", "getOwnPropertyDescriptors", "sin", "isInteger", "values", "isArray", "cos", "lastIndexOf", "setPrototypeOf", "endsWith", "repeat", "getUint16", "getUTCMinutes", "isFinite", "setSeconds", "subarray", "keyFor", "call", "setMonth", "splice", "acos", "UTC", "flatMap", "getMinutes", "pow", "assign", "of", "getUTCHours", "setMilliseconds", "getFullYear", "asinh", "copyWithin", "getInt32", "bind", "concat", "setInt16", "setFloat64", "getUTCDay", "substring", "create", "parse", "compile", "isSealed", "deref", "min", "deleteProperty", "trimStart", "forEach", "get", "asIntN", "setTime", "getPrototypeOf", "asUintN", "getBigInt64", "unshift", "reduceRight", "exp", "round", "resolve", "setUTCFullYear", "trim", "fromEntries", "toTimeString", "getUTCSeconds", "codePointAt", "has", "setYear", "for", "setUTCMinutes", "trunc", "includes", "toUpperCase", "fround", "getTime", "reverse", "split", "toString", "setUint16", "trimEnd", "register", "setUint32", "flat", "any", "setBigInt64", "all", "tan", "getOwnPropertyNames", "find", "getFloat64", "reduce", "charAt", "then", "reject", "fromCharCode", "unregister", "setUTCSeconds", "cosh", "isSafeInteger", "imul", "return", "setDate", "expm1", "abs", "grow", "valueOf", "set", "atanh", "getUint32", "defineProperty", "padStart", "setUint8", "setUTCMonth", "ownKeys", "is", "getFloat32", "setInt8", "charCodeAt", "setInt32", "toDateString", "setUTCDate", "toLocaleString", "catch", "map", "test", "setUTCHours", "now", "getMonth", "delete", "isExtensible", "trimRight", "keys", "sign", "normalize", "setMinutes", "freeze", "getUTCFullYear", "apply", "toJSON", "log", "getUTCMonth", "add", "getDay", "getYear", "toISOString", "resize", "construct", "isView", "matchAll", "exec", "getSeconds", "ceil", "match", "getInt16", "pop", "next", "preventExtensions", "log10", "finally", "allSettled", "getOwnPropertySymbols", "every", "join", "getUTCMilliseconds", "asin", "throw", "cbrt", "getOwnPropertyDescriptor", "localeCompare", "max", "entries", "stringify", "some", "replace", "isNaN", "slice", "isFrozen", "findIndex", "getUTCDate", "defineProperties"]
[JavaScriptEnvironment] Have 8 custom property names: ["d", "h", "e", "g", "a", "c", "b", "f"]
[JavaScriptEnvironment] Have 6 custom method names: ["p", "m", "n", "o", "valueOf", "toString"]
[Fuzzer] Changing state from uninitialized to corpusGeneration
[Fuzzer] Initialized
[Fuzzer] Recommended timeout: at least 100ms. Current timeout: 250ms
[Fuzzer] Startup tests finished successfully
[Fuzzer] Let's go!
[Fuzzer] Initial corpus generation failed, corpus is still empty. Is the evaluator working correctly?
[Fuzzer] Shutting down due to fatal error
```

</details>

It seems to generate some interesting cases immediately, such as

```
function main() {
class C1 {
    static {
        const t3 = 1438522328n;
        t3();
    }
}
}
main()
```

