### PR TITLE
Add missing Array and TypedArray prototype properties to environment

### DIFF
--- a/Sources/Fuzzilli/Environment/JavaScriptEnvironment.swift
+++ b/Sources/Fuzzilli/Environment/JavaScriptEnvironment.swift
@@ -583,7 +583,7 @@ public extension ILType {
 
     /// Type of a JavaScript TypedArray object of the given variant.
     static func jsTypedArray(_ variant: String) -> ILType {
-        return .iterable + .object(ofGroup: variant, withProperties: ["buffer", "byteOffset", "byteLength", "length"], withMethods: ["copyWithin", "fill", "find", "findIndex", "reverse", "slice", "sort", "includes", "indexOf", "keys", "entries", "forEach", "filter", "map", "every", "set", "some", "subarray", "reduce", "reduceRight", "join", "lastIndexOf", "values", "toLocaleString", "toString"])
+        return .iterable + .object(ofGroup: variant, withProperties: ["buffer", "byteOffset", "byteLength", "length"], withMethods: ["at", "copyWithin", "fill", "find", "findIndex", "findLast", "findLastIndex", "reverse", "slice", "sort", "includes", "indexOf", "keys", "entries", "forEach", "filter", "map", "every", "set", "some", "subarray", "reduce", "reduceRight", "join", "lastIndexOf", "values", "toLocaleString", "toString", "toReversed", "toSorted", "with"])
     }
 
     /// Type of a JavaScript function.
@@ -1034,12 +1034,15 @@ public extension ObjectGroup {
                 "length"      : .integer
             ],
             methods: [
+                "at"          : [.integer] => .anything,
                 "copyWithin"  : [.integer, .integer, .opt(.integer)] => .undefined,
                 "entries"     : [] => .jsArray,
                 "every"       : [.function(), .opt(.object())] => .boolean,
                 "fill"        : [.anything, .opt(.integer), .opt(.integer)] => .undefined,
                 "find"        : [.function(), .opt(.object())] => .anything,
                 "findIndex"   : [.function(), .opt(.object())] => .integer,
+                "findLast"    : [.function(), .opt(.object())] => .anything,
+                "findLastIndex"  : [.function(), .opt(.object())] => .integer,
                 "forEach"     : [.function(), .opt(.object())] => .undefined,
                 "includes"    : [.anything, .opt(.integer)] => .boolean,
                 "indexOf"     : [.anything, .opt(.integer)] => .integer,
@@ -1058,7 +1061,10 @@ public extension ObjectGroup {
                 "slice"       : [.opt(.integer), .opt(.integer)] => .jsTypedArray(variant),
                 "subarray"    : [.opt(.integer), .opt(.integer)] => .jsTypedArray(variant),
                 "toString"       : [] => .jsString,
-                "toLocaleString" : [.opt(.string), .opt(.object())] => .jsString
+                "toLocaleString" : [.opt(.string), .opt(.object())] => .jsString,
+                "toReversed"     : [] => .jsTypedArray(variant),
+                "toSorted"       : [.opt(.function())] => .jsTypedArray(variant),
+                "with"           : [.integer, .anything] => .jsTypedArray(variant),
             ]
         )
     }

--- a/Sources/Fuzzilli/Environment/JavaScriptEnvironment.swift
+++ b/Sources/Fuzzilli/Environment/JavaScriptEnvironment.swift
@@ -543,7 +543,7 @@ public extension ILType {
     static let jsSymbol = ILType.object(ofGroup: "Symbol", withProperties: ["description"])
 
     /// Type of a JavaScript array.
-    static let jsArray = ILType.iterable + ILType.object(ofGroup: "Array", withProperties: ["length"], withMethods: ["at", "concat", "copyWithin", "fill", "find", "findIndex", "pop", "push", "reverse", "shift", "unshift", "slice", "sort", "splice", "includes", "indexOf", "keys", "entries", "forEach", "filter", "map", "every", "some", "reduce", "reduceRight", "toString", "toLocaleString", "join", "lastIndexOf", "values", "flat", "flatMap"])
+    static let jsArray = ILType.iterable + ILType.object(ofGroup: "Array", withProperties: ["length"], withMethods: ["at", "concat", "copyWithin", "fill", "find", "findIndex", "findLast", "findLastIndex", "pop", "push", "reverse", "shift", "unshift", "slice", "sort", "splice", "includes", "indexOf", "keys", "entries", "forEach", "filter", "map", "every", "some", "reduce", "reduceRight", "toString", "toLocaleString", "toReversed", "toSorted", "toSpliced", "with", "join", "lastIndexOf", "values", "flat", "flatMap"])
 
     /// Type of a function's arguments object.
     static let jsArguments = ILType.iterable + ILType.object(ofGroup: "Arguments", withProperties: ["length", "callee"])
@@ -810,6 +810,8 @@ public extension ObjectGroup {
             "fill"           : [.anything, .opt(.integer), .opt(.integer)] => .undefined,
             "find"           : [.function(), .opt(.object())] => .anything,
             "findIndex"      : [.function(), .opt(.object())] => .integer,
+            "findLast"       : [.function(), .opt(.object())] => .anything,
+            "findLastIndex"  : [.function(), .opt(.object())] => .integer,
             "forEach"        : [.function(), .opt(.object())] => .undefined,
             "includes"       : [.anything, .opt(.integer)] => .boolean,
             "indexOf"        : [.anything, .opt(.integer)] => .integer,
@@ -835,6 +837,10 @@ public extension ObjectGroup {
             "flatMap"        : [.function(), .opt(.anything)] => .jsArray,
             "toString"       : [] => .jsString,
             "toLocaleString" : [.opt(.string), .opt(.object())] => .jsString,
+            "toReversed"     : [] => .jsArray,
+            "toSorted"       : [.opt(.function())] => .jsArray,
+            "toSpliced"      : [.integer, .opt(.integer), .anything...] => .jsArray,
+            "with"           : [.integer, .anything] => .jsArray,
         ]
     )
 


### PR DESCRIPTION
Although ProbingMutator can probably find these properties, I thought it might be a good idea to give CodeGenMutator a chance to also generate code with the following properties:
- https://262.ecma-international.org/14.0/#sec-array.prototype.findlast
- https://262.ecma-international.org/14.0/#sec-array.prototype.findlastindex
- https://262.ecma-international.org/14.0/#sec-array.prototype.toreversed
- https://262.ecma-international.org/14.0/#sec-array.prototype.tosorted
- https://262.ecma-international.org/14.0/#sec-array.prototype.tospliced
- https://262.ecma-international.org/14.0/#sec-array.prototype.with

- https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.at
- https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.findindex
- https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.findlastindex
- https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.toreversed
- https://262.ecma-international.org/14.0/#sec-%typedarray%.prototype.tosorted
