### PR TITLE
Add support for running on macOS with the target jsc build

### DIFF
--- a/Sources/Fuzzilli/Execution/REPRL.swift
+++ b/Sources/Fuzzilli/Execution/REPRL.swift
@@ -49,6 +49,14 @@ public class REPRL: ComponentBase, ScriptRunner {
         self.maxExecsBeforeRespawn = maxExecsBeforeRespawn
         super.init(name: "REPRL")
 
+        #if os(macOS)
+            // Make sure that the DYLD_FRAMEWORK_PATH have been correctly set
+            // Only when the name of executable is jsc
+            if executable.suffix(4) == "/jsc" {
+                env.append("DYLD_FRAMEWORK_PATH=" + executable.components(separatedBy: "jsc")[0])
+            }
+        #endif
+
         for (key, value) in processEnvironment {
             env.append(key + "=" + value)
         }

--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -48,7 +48,7 @@ fileprivate protocol MessageHandler {
 /// A connection to a network peer that speaks the above protocol.
 fileprivate class Connection {
     /// The file descriptor on POSIX or SOCKET handle on Windows of the socket.
-    let socket: libsocket.socket_t
+    let socket: libsocket.socket_fd
 
     /// The UUID of the remote end.
     let localId: UUID
@@ -78,7 +78,7 @@ fileprivate class Connection {
     /// Pending outgoing data. Must only be accessed on this connection's dispatch queue.
     private var sendQueue: [Data] = []
 
-    init?(socket: libsocket.socket_t, localId: UUID, handler: MessageHandler) {
+    init?(socket: libsocket.socket_fd, localId: UUID, handler: MessageHandler) {
         self.socket = socket
         self.localId = localId
         self.handler = handler
@@ -331,7 +331,7 @@ public class NetworkParent: DistributedFuzzingParentNode {
         unowned let fuzzer: Fuzzer
 
         /// File descriptor or SOCKET handle of the server socket.
-        private var serverFd: libsocket.socket_t = INVALID_SOCKET
+        private var serverFd: libsocket.socket_fd = INVALID_SOCKET
 
         /// Address and port on which to listen for connections.
         private let address: String
@@ -346,7 +346,7 @@ public class NetworkParent: DistributedFuzzingParentNode {
         private var serverQueue: DispatchQueue? = nil
 
         /// Active workers indexed by the socket used to communicate with them.
-        private var clientsBySocket = [libsocket.socket_t: Client]()
+        private var clientsBySocket = [libsocket.socket_fd: Client]()
 
         /// Active workers indexed by their id.
         private var clientsById = [UUID: Client]()
@@ -445,7 +445,7 @@ public class NetworkParent: DistributedFuzzingParentNode {
             onChildDisconnectedCallback = callback
         }
 
-        private func handleNewConnection(_ socket: libsocket.socket_t) {
+        private func handleNewConnection(_ socket: libsocket.socket_fd) {
             guard socket > 0 else {
                 return logger.error("Failed to accept client connection")
             }

--- a/Sources/FuzzilliCli/Profiles/JSCProfile.swift
+++ b/Sources/FuzzilliCli/Profiles/JSCProfile.swift
@@ -49,8 +49,12 @@ let jscProfile = Profile(
             "--thresholdForFTLOptimizeAfterWarmUp=1000",
             "--thresholdForFTLOptimizeSoon=1000",
             // Enable bounds check elimination validation
-            "--validateBCE=true",
+            //"--validateBCE=true",
             "--reprl"]
+        
+        #if !os(macOS)
+        args.append("--validateBCE=true")
+        #endif
 
         guard randomize else { return args }
 

--- a/Sources/REPRLRun/main.swift
+++ b/Sources/REPRLRun/main.swift
@@ -37,7 +37,12 @@ if ctx == nil {
 }
 
 let argv = convertToCArray(Array(CommandLine.arguments[1...]))
+#if os(macOS)
+// Set the DYLD_FRAMEWORK_PATH env variable for the shell to run
+let envp = convertToCArray(["DYLD_FRAMEWORK_PATH=\(String(CommandLine.arguments[1].prefix(CommandLine.arguments[1].count-3)))"])
+#else
 let envp = convertToCArray([])
+#endif
 if reprl_initialize_context(ctx, argv, envp, /* capture_stdout: */ 1, /* capture stderr: */ 1) != 0 {
     print("Failed to initialize REPRL context: \(String(cString: reprl_get_last_error(ctx)))")
 }

--- a/Sources/libsocket/include/libsocket.h
+++ b/Sources/libsocket/include/libsocket.h
@@ -22,7 +22,7 @@
 #endif
 
 #if defined(_WIN32)
-typedef SOCKET socket_t;
+typedef SOCKET socket_fd;
 
 // We need C11 or newer due to the use of `_Generic`.  Windows does not have a
 // signed size type, so we construct the equivalent type by inspecting the type
@@ -36,18 +36,18 @@ typedef __typeof__(_Generic((size_t)0,                                  \
                             unsigned char : (char)0)) ssize_t;
 #endif
 #else
-typedef int socket_t;
+typedef int socket_fd;
 #define INVALID_SOCKET (-1)
 #endif
 
-socket_t socket_listen(const char* address, uint16_t port);
-socket_t socket_accept(socket_t socket);
-socket_t socket_connect(const char* address, uint16_t port);
+socket_fd socket_listen(const char* address, uint16_t port);
+socket_fd socket_accept(socket_fd socket);
+socket_fd socket_connect(const char* address, uint16_t port);
 
-ssize_t socket_send(socket_t socket, const uint8_t* data, size_t length);
-ssize_t socket_recv(socket_t socket, uint8_t* buffer, size_t length);
+ssize_t socket_send(socket_fd socket, const uint8_t* data, size_t length);
+ssize_t socket_recv(socket_fd socket, uint8_t* buffer, size_t length);
 
-int socket_shutdown(socket_t socket);
-int socket_close(socket_t socket);
+int socket_shutdown(socket_fd socket);
+int socket_close(socket_fd socket);
 
 #endif

--- a/Sources/libsocket/socket-posix.c
+++ b/Sources/libsocket/socket-posix.c
@@ -24,8 +24,8 @@
 #include <string.h>
 #include <unistd.h>
 
-socket_t socket_listen(const char* address, uint16_t port) {
-    socket_t fd = socket(AF_INET, SOCK_STREAM, 0);
+socket_fd socket_listen(const char* address, uint16_t port) {
+    socket_fd fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {
         return INVALID_SOCKET;
     }
@@ -54,8 +54,8 @@ socket_t socket_listen(const char* address, uint16_t port) {
     return fd;
 }
 
-socket_t socket_accept(socket_t fd) {
-    socket_t client_fd = accept(fd, NULL, 0);
+socket_fd socket_accept(socket_fd fd) {
+    socket_fd client_fd = accept(fd, NULL, 0);
     if (client_fd < 0) {
         return INVALID_SOCKET;
     }
@@ -78,7 +78,7 @@ socket_t socket_accept(socket_t fd) {
     return client_fd;
 }
 
-socket_t socket_connect(const char* address, uint16_t port) {
+socket_fd socket_connect(const char* address, uint16_t port) {
     struct addrinfo hint;
     memset(&hint, 0, sizeof(hint));
     hint.ai_family = AF_UNSPEC;
@@ -93,7 +93,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
         return INVALID_SOCKET;
     }
 
-    socket_t fd;
+    socket_fd fd;
     struct addrinfo* addr;
     for (addr = result; addr != NULL; addr = addr->ai_next) {
         fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
@@ -133,7 +133,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
     return fd;
 }
 
-ssize_t socket_send(socket_t fd, const uint8_t* data, size_t length) {
+ssize_t socket_send(socket_fd fd, const uint8_t* data, size_t length) {
     ssize_t remaining = length;
     while (remaining > 0) {
 #ifdef __APPLE__
@@ -154,15 +154,15 @@ ssize_t socket_send(socket_t fd, const uint8_t* data, size_t length) {
     return length;
 }
 
-ssize_t socket_recv(socket_t fd, uint8_t* data, size_t length) {
+ssize_t socket_recv(socket_fd fd, uint8_t* data, size_t length) {
     return read(fd, data, length);
 }
 
-int socket_shutdown(socket_t socket) {
+int socket_shutdown(socket_fd socket) {
     return shutdown(socket, SHUT_RDWR);
 }
 
-int socket_close(socket_t fd) {
+int socket_close(socket_fd fd) {
     return close(fd);
 }
 

--- a/Sources/libsocket/socket-win32.c
+++ b/Sources/libsocket/socket-win32.c
@@ -44,8 +44,8 @@ static void __attribute__((__destructor__, __used__)) libsocket_fini(void) {
     (void)WSACleanup();
 }
 
-socket_t socket_listen(const char *address, uint16_t port) {
-    socket_t sock = socket(AF_INET, SOCK_STREAM, 0);
+socket_fd socket_listen(const char *address, uint16_t port) {
+    socket_fd sock = socket(AF_INET, SOCK_STREAM, 0);
     if (sock == INVALID_SOCKET)
         return INVALID_SOCKET;
 
@@ -68,8 +68,8 @@ socket_t socket_listen(const char *address, uint16_t port) {
     return sock;
 }
 
-socket_t socket_accept(socket_t sock) {
-    socket_t client = accept(sock, NULL, NULL);
+socket_fd socket_accept(socket_fd sock) {
+    socket_fd client = accept(sock, NULL, NULL);
     if (client == INVALID_SOCKET)
         return INVALID_SOCKET;
 
@@ -82,7 +82,7 @@ socket_t socket_accept(socket_t sock) {
     return client;
 }
 
-socket_t socket_connect(const char *address, uint16_t port) {
+socket_fd socket_connect(const char *address, uint16_t port) {
     struct addrinfo ai;
     ZeroMemory(&ai, sizeof(ai));
     ai.ai_family = AF_UNSPEC;
@@ -96,7 +96,7 @@ socket_t socket_connect(const char *address, uint16_t port) {
     if (getaddrinfo(address, port_str, &ai, &ai_list))
         return INVALID_SOCKET;
 
-    socket_t sock;
+    socket_fd sock;
     struct addrinfo *ai_cur;
     for (ai_cur = ai_list; ai_cur; ai_cur = ai_cur->ai_next) {
         sock = socket(ai_cur->ai_family, ai_cur->ai_socktype, ai_cur->ai_protocol);
@@ -124,7 +124,7 @@ socket_t socket_connect(const char *address, uint16_t port) {
     return sock;
 }
 
-ssize_t socket_send(socket_t sock, const uint8_t *data, size_t length) {
+ssize_t socket_send(socket_fd sock, const uint8_t *data, size_t length) {
     assert(length <= INT_MAX && "unable to send > INT_MAX bytes");
     ssize_t remaining = length;
     while (remaining) {
@@ -137,16 +137,16 @@ ssize_t socket_send(socket_t sock, const uint8_t *data, size_t length) {
     return length;
 }
 
-ssize_t socket_recv(socket_t sock, uint8_t *buffer, size_t length) {
+ssize_t socket_recv(socket_fd sock, uint8_t *buffer, size_t length) {
     assert(length <= INT_MAX && "unable to receive >INT_MAX bytes");
     return recv(sock, (char *)buffer, length, 0);
 }
 
-int socket_shutdown(socket_t socket) {
+int socket_shutdown(socket_fd socket) {
     return shutdown(socket, SD_BOTH);
 }
 
-int socket_close(socket_t socket) {
+int socket_close(socket_fd socket) {
     return closesocket(socket);
 }
 

--- a/Targets/JavaScriptCore/fuzzbuild.sh
+++ b/Targets/JavaScriptCore/fuzzbuild.sh
@@ -18,6 +18,10 @@ export WEBKIT_OUTPUTDIR=FuzzBuild
 
 if [ "$(uname)" == "Linux" ]; then
     ./Tools/Scripts/build-jsc --jsc-only --debug --cmakeargs="-DENABLE_STATIC_JSC=ON -DCMAKE_C_COMPILER='/usr/bin/clang' -DCMAKE_CXX_COMPILER='/usr/bin/clang++' -DCMAKE_CXX_FLAGS='-fsanitize-coverage=trace-pc-guard -O3 -lrt'"
+elif [ "$(uname)" == "Darwin" ]; then
+    unset WEBKIT_OUTPUTDIR # remove the outputdir env on macOS for the build without cmake will be in the Source directory(maybe the build-jsc have problem)
+    ./Tools/Scripts/set-webkit-configuration --debug --analyze --coverage --force-optimization-level=O3 
+    ./Tools/Scripts/build-jsc
 else
     echo "Unsupported operating system"
 fi


### PR DESCRIPTION
Cheak whether this cannot run on macOS and restore the fuzzbuild shell for macOS build which use the build-jsc shell without not officially supported "--jsc-only" port

Also fix the REPRL and main fuzzer code to deal with the jsc executable path input which lead to the executeable file cannot run on macOS for the env not properly set

The problem is that on macOS with the test tag I have used is "releases/Apple/Safari-14.0.3-macOS-11.2.3", and on the ubuntu it has coverage edges almost 960000+ and only 12000+ on mac.（Here I have found that this problem is caused the JavascriptCore.framework build, I now try to change it like WTF to build a .a library）