### PR TITLE
Fixes Switch Break Bug

### DIFF
--- a/Sources/Fuzzilli/Compiler/Compiler.swift
+++ b/Sources/Fuzzilli/Compiler/Compiler.swift
@@ -448,7 +448,7 @@ public class JavaScriptCompiler {
             // (switch blocks don't propagate an outer .loop context) so we just need to check for .loop here
             if contextAnalyzer.context.contains(.loop){
                 emit(LoopBreak())
-            } else if contextAnalyzer.context.contains(.switchBlock){
+            } else if contextAnalyzer.context.contains(.switchCase) {
                 emit(SwitchBreak())
             } else {
                 throw CompilerError.invalidNodeError("break statement outside of loop or switch")


### PR DESCRIPTION
Bug can be seen when trying to compile Tests/FuzzilliTests/CompilerTests/switch_statements.js, which fails because "break statement outside of loop or switch", even though it isn't. This happens because breaks are expected in switch cases, rather than the switch block. 

This was missed because compilation was succesful before moving the Analyzer changes to a separate branch and verification of the new ContextAnalyzer was only done with Tests/FuzzilliTests/AnalyzerTest.swift and not with Tests/CompilerTests/switch_statements.js