### PR TITLE
Implements compilation of the delete operator

### DIFF
--- a/Sources/Fuzzilli/Compiler/Compiler.swift
+++ b/Sources/Fuzzilli/Compiler/Compiler.swift
@@ -983,9 +983,8 @@ public class JavaScriptCompiler {
             }
 
         case .unaryExpression(let unaryExpression):
-            let argument = try compileExpression(unaryExpression.argument)
-
             if unaryExpression.operator == "typeof" {
+                let argument = try compileExpression(unaryExpression.argument)
                 return emit(TypeOf(), withInputs: [argument]).output
             } else if unaryExpression.operator == "delete" {
                 guard case .memberExpression(let memberExpression) = unaryExpression.argument.expression else {
@@ -1031,6 +1030,7 @@ public class JavaScriptCompiler {
                 guard let op = UnaryOperator(rawValue: unaryExpression.operator) else {
                     throw CompilerError.invalidNodeError("invalid unary operator: \(unaryExpression.operator)")
                 }
+                let argument = try compileExpression(unaryExpression.argument)
                 return emit(UnaryOperation(op), withInputs: [argument]).output
             }
 

--- a/Sources/Fuzzilli/Compiler/Compiler.swift
+++ b/Sources/Fuzzilli/Compiler/Compiler.swift
@@ -988,45 +988,44 @@ public class JavaScriptCompiler {
             if unaryExpression.operator == "typeof" {
                 return emit(TypeOf(), withInputs: [argument]).output
             } else if unaryExpression.operator == "delete" {
-                let argumentExpression = unaryExpression.argument.expression!
+                guard case .memberExpression(let memberExpression) = unaryExpression.argument.expression else {
+                    throw CompilerError.invalidNodeError("delete operator must be applied to a member expression")
+                }
 
-                if case .memberExpression(let memberExpression) = argumentExpression {
-                    let obj = try compileExpression(memberExpression.object)
-                    let isGuarded = memberExpression.isOptional
+                let obj = try compileExpression(memberExpression.object)
+                // isGuarded is true if the member expression is optional (e.g., obj?.prop)
+                let isGuarded = memberExpression.isOptional
 
-                    if memberExpression.name != "" {
-                        // Deleting a non-computed property (e.g., delete obj.prop)
-                        let propertyName = memberExpression.name
+                if !memberExpression.name.isEmpty {
+                    // Deleting a non-computed property (e.g., delete obj.prop)
+                    let propertyName = memberExpression.name
+                    let instr = emit(
+                        DeleteProperty(propertyName: propertyName, isGuarded: isGuarded),
+                        withInputs: [obj]
+                    )
+                    return instr.output
+                } else {
+                    // Deleting a computed property (e.g., delete obj[expr])
+                    let propertyExpression = memberExpression.expression
+                    let propertyExpr = propertyExpression.expression
+                    let property = try compileExpression(propertyExpression)
+
+                    if case .numberLiteral(let numberLiteral) = propertyExpr {
+                        // Delete an element (e.g., delete arr[42])
+                        let index = Int64(numberLiteral.value)
                         let instr = emit(
-                            DeleteProperty(propertyName: propertyName, isGuarded: isGuarded),
+                            DeleteElement(index: index, isGuarded: isGuarded),
                             withInputs: [obj]
                         )
                         return instr.output
                     } else {
-                        // Deleting a computed property (e.g., delete obj[expr])
-                        let propertyExpression = memberExpression.expression
-                        let propertyExpr = propertyExpression.expression
-                        let property = try compileExpression(propertyExpression)
-
-                        if case .numberLiteral(let numberLiteral) = propertyExpr {
-                            // Delete an element (e.g., delete arr[42])
-                            let index = Int64(numberLiteral.value)
-                            let instr = emit(
-                                DeleteElement(index: index, isGuarded: isGuarded),
-                                withInputs: [obj]
-                            )
-                            return instr.output
-                        } else {
-                            // Use DeleteComputedProperty for other computed properties (e.g., delete obj["key"])
-                            let instr = emit(
-                                DeleteComputedProperty(isGuarded: isGuarded),
-                                withInputs: [obj, property]
-                            )
-                            return instr.output
-                        }
+                        // Use DeleteComputedProperty for other computed properties (e.g., delete obj["key"])
+                        let instr = emit(
+                            DeleteComputedProperty(isGuarded: isGuarded),
+                            withInputs: [obj, property]
+                        )
+                        return instr.output
                     }
-                } else {
-                    throw CompilerError.invalidNodeError("Invalid argument for delete operator; expected a member expression")
                 }
             } else {
                 guard let op = UnaryOperator(rawValue: unaryExpression.operator) else {

--- a/Tests/FuzzilliTests/CompilerTests/basic_delete.js
+++ b/Tests/FuzzilliTests/CompilerTests/basic_delete.js
@@ -1,0 +1,22 @@
+if (typeof output === 'undefined') output = console.log;
+
+const obj = { a: 1 };
+console.log(delete obj.a);
+console.log(obj);
+
+const propName = 'b';
+obj[propName] = 2;
+console.log(delete obj[propName]);
+console.log(obj);
+
+const arr = [1, 2, 3];
+console.log(delete arr[1]);
+console.log(arr);
+
+const index = 0;
+console.log(delete arr[index]);
+console.log(arr);
+
+const nestedObj = { a: { b: 2 } };
+console.log(delete nestedObj?.a?.b);
+console.log(nestedObj);

--- a/Tests/FuzzilliTests/CompilerTests/basic_delete.js
+++ b/Tests/FuzzilliTests/CompilerTests/basic_delete.js
@@ -20,3 +20,10 @@ console.log(arr);
 const nestedObj = { a: { b: 2 } };
 console.log(delete nestedObj?.a?.b);
 console.log(nestedObj);
+
+try {
+    delete null.a;
+} catch(e) {
+    console.log(e.message);
+}
+console.log(delete null?.a);


### PR DESCRIPTION
This branches enables compilation of the delete operator. Some thoughts I think are worth mentioning

### 1) 

With this change, approximately 300 new seeds from test/mjsunit and the SpiderMonkey JIT test files will become compilable. If Fuzzilli treats the delete operation as a standard unary operator, delete might be applied to non-object properties, such as simple variables (var). If I understand correctly, semantic correctness will not be significantly impacted because delete does not cause a crash when called on unintended targets. For example, if applied to var, let, or parameters, it simply returns false and has no effect.

### 2) 

It can happen that an object has a key that is a number. In that case DeleteElement will be called, even though it is not an array.
Example:
```
const obj = { 1: 'value' };
delete obj[1];
```
Similarly, we can delete elements from an array based on a computed index - in that case DeleteComputedProperty is called, not DeleteElement.

Example
```
const arr = [1, 2, 3];
delete arr[Math.floor(Math.random() * arr.length)];
```
 Is that a problem? IIUC, the main difference between DeleteElement and Delete(Computed)Property In FuzzIL is only syntactical, not semantical.