### PR TITLE
Implements compilation of string literal keys

### DIFF
--- a/Sources/Fuzzilli/Compiler/Parser/parser.js
+++ b/Sources/Fuzzilli/Compiler/Parser/parser.js
@@ -159,6 +159,8 @@ function parse(script, proto) {
                                 property.name = field.key.name;
                             } else if (field.key.type === 'NumericLiteral') {
                                 property.index = field.key.value;
+                            } else if (field.key.type === 'StringLiteral') {
+                                property.name = field.key.value;
                             } else {
                                 throw "Unknown property key type: " + field.key.type + " in class declaration";
                             }
@@ -407,6 +409,8 @@ function parse(script, proto) {
                                 property.name = field.key.name;
                             } else if (field.key.type === 'NumericLiteral') {
                                 property.index = field.key.value;
+                            } else if (field.key.type === 'StringLiteral') {
+                                property.name = field.key.value;
                             } else {
                                 throw "Unknown property key type: " + field.key.type;
                             }


### PR DESCRIPTION
Currently we support only this:

`const obj = { a : 1 };`

This is **not** supported:

`const obj = { "a" : 1 };`

Even though it is the same thing, just with a different representation. See this:
https://www.reddit.com/r/typescript/comments/1ac7b68/in_javascript_object_keysproperties_are_strings/?rdt=50433