### PR TITLE
bugfix/livetests

### DIFF
--- a/Tests/FuzzilliTests/LiveTests.swift
+++ b/Tests/FuzzilliTests/LiveTests.swift
@@ -33,8 +33,8 @@ class LiveTests: XCTestCase {
             b.buildPrefix()
         }
 
-        // We expect a maximum of 10% of ValueGeneration to fail
-        checkFailureRate(testResults: results, maxFailureRate: 0.10)
+        // We expect a maximum of 19.5% of ValueGeneration to fail (mean + 3 * stdDev of failure rate)
+        checkFailureRate(testResults: results, maxFailureRate: 0.195)
     }
 
     // The closure can use the ProgramBuilder to emit a program of a specific


### PR DESCRIPTION
The threshold in `LiveTests.swift` for the failure rate seems to be too low. The test fails or succeeds by chance. I have set the threshold to the mean plus three standard deviations, reducing the false positive rate to approximately 0.3%.