### PR TITLE
feature/loopNestedContinue

### DIFF
--- a/Sources/Fuzzilli/Base/ProgramBuilder.swift
+++ b/Sources/Fuzzilli/Base/ProgramBuilder.swift
@@ -2822,6 +2822,10 @@ public class ProgramBuilder {
         emit(Print(), withInputs: [value])
     }
 
+    public func loopNestedContinue(_ depth: Int){
+        emit(LoopNestedContinue(depth), withInputs: [])
+    }
+
 
     @discardableResult
     public func createWasmGlobal(value: WasmGlobal, isMutable: Bool) -> Variable {

--- a/Sources/Fuzzilli/CodeGen/CodeGeneratorWeights.swift
+++ b/Sources/Fuzzilli/CodeGen/CodeGeneratorWeights.swift
@@ -169,6 +169,7 @@ public let codeGeneratorWeights = [
     "TryCatchGenerator":                        5,
     "ThrowGenerator":                           1,
     "BlockStatementGenerator":                  1,
+    "LoopNestedContinueGenerator":              1,
 
     // Special generators
     "WellKnownPropertyLoadGenerator":           5,

--- a/Sources/Fuzzilli/CodeGen/CodeGenerators.swift
+++ b/Sources/Fuzzilli/CodeGen/CodeGenerators.swift
@@ -54,7 +54,7 @@ public let CodeGenerators: [CodeGenerator] = [
     ValueGenerator("StringGenerator") { b, n in
         for _ in 0..<n {
             b.loadString(b.randomString())
-        }
+        }   
     },
 
     ValueGenerator("BooleanGenerator") { b, n in
@@ -1866,6 +1866,10 @@ public let CodeGenerators: [CodeGenerator] = [
             b.callFunction(f, withArgs: args)
         }, catchBody: { _ in })
     },
+
+    CodeGenerator("LoopNestedContinueGenerator", inContext: .loop) { b in
+        b.loopNestedContinue(Int.random(in: 0...10))
+    }
 ]
 
 extension Array where Element == CodeGenerator {

--- a/Sources/Fuzzilli/FuzzIL/Instruction.swift
+++ b/Sources/Fuzzilli/FuzzIL/Instruction.swift
@@ -1030,6 +1030,8 @@ extension Instruction: ProtobufConvertible {
                 $0.wrapSuspending = Fuzzilli_Protobuf_WrapSuspending()
             case .bindMethod(let op):
                 $0.bindMethod = Fuzzilli_Protobuf_BindMethod.with { $0.methodName = op.methodName }
+            case .loopNestedContinue:
+                $0.loopNestedContinue = Fuzzilli_Protobuf_LoopNestedContinue()
             case .print(_):
                 fatalError("Print operations should not be serialized")
             // Wasm Operations
@@ -1892,6 +1894,8 @@ extension Instruction: ProtobufConvertible {
             op = LoadNewTarget()
         case .nop:
             op = Nop()
+        case .loopNestedContinue(let d):   
+            op = LoopNestedContinue(d.depth)
         case .createWasmGlobal(let p):
             op = CreateWasmGlobal(value: convertWasmGlobal(p.wasmGlobal), isMutable: p.wasmGlobal.isMutable)
         case .createWasmMemory(let p):

--- a/Sources/Fuzzilli/FuzzIL/JsOperations.swift
+++ b/Sources/Fuzzilli/FuzzIL/JsOperations.swift
@@ -2256,7 +2256,7 @@ final class BeginFinally: JsOperation {
 
 final class EndTryCatchFinally: JsOperation {
     override var opcode: Opcode { .endTryCatchFinally(self) }
-
+ 
     init() {
         super.init(attributes: [.isBlockEnd])
     }
@@ -2461,6 +2461,17 @@ class BindMethod: JsOperation {
         self.methodName = methodName
         // TODO(cffsmith): We probably want to expand this in the future to also bind arguments at some point.
         super.init(numInputs: 1, numOutputs: 1, requiredContext: .javascript)
+    }
+}
+
+final class LoopNestedContinue: JsOperation {
+    override var opcode: Opcode { .loopNestedContinue(self) }
+
+    let depth: Int
+
+    init(_ depth: Int) {
+        self.depth = depth
+        super.init(attributes: [.isJump], requiredContext: [.javascript, .loop])
     }
 }
 

--- a/Sources/Fuzzilli/FuzzIL/Opcodes.swift
+++ b/Sources/Fuzzilli/FuzzIL/Opcodes.swift
@@ -202,6 +202,7 @@ enum Opcode {
     case endSwitch(EndSwitch)
     case switchBreak(SwitchBreak)
     case loadNewTarget(LoadNewTarget)
+    case loopNestedContinue(LoopNestedContinue)
     case print(Print)
     case explore(Explore)
     case probe(Probe)

--- a/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
+++ b/Sources/Fuzzilli/Lifting/FuzzILLifter.swift
@@ -753,6 +753,9 @@ public class FuzzILLifter: Lifter {
         case .loadNewTarget:
             w.emit("\(output()) <- LoadNewTarget")
 
+        case .loopNestedContinue(let op):
+            w.emit("LoopNestedContinue \(op.depth)")
+
         case .beginWasmModule:
             w.emit("BeginWasmModule")
             w.increaseIndentionLevel()

--- a/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
+++ b/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift
@@ -101,6 +101,8 @@ public class JavaScriptLifter: Lifter {
 
         var w = JavaScriptWriter(analyzer: analyzer, version: version, stripComments: !options.contains(.includeComments), includeLineNumbers: options.contains(.includeLineNumbers))
 
+        var loopLabelStack = LabelStack(type: .loopblock)
+
         var wasmCodeStarts: Int? = nil
 
         if options.contains(.includeComments), let header = program.comments.at(.header) {
@@ -1150,14 +1152,19 @@ public class JavaScriptLifter: Lifter {
 
             case .beginWhileLoopBody:
                 let COND = handleEndSingleExpressionContext(result: input(0), with: &w)
+                loopLabelStack.push(currentCodeLength: w.code.count)
                 w.emitBlock("while (\(COND)) {")
                 w.enterNewBlock()
+
 
             case .endWhileLoop:
                 w.leaveCurrentBlock()
                 w.emit("}")
+                loopLabelStack.pop()
+
 
             case .beginDoWhileLoopBody:
+                loopLabelStack.push(currentCodeLength: w.code.count)
                 w.emit("do {")
                 w.enterNewBlock()
 
@@ -1168,6 +1175,7 @@ public class JavaScriptLifter: Lifter {
             case .endDoWhileLoop:
                 let COND = handleEndSingleExpressionContext(result: input(0), with: &w)
                 w.emitBlock("} while (\(COND))")
+                loopLabelStack.pop()
 
             case .beginForLoopInitializer:
                 // While we could inline into the loop header, we probably don't want to do that as it will often lead
@@ -1243,6 +1251,7 @@ public class JavaScriptLifter: Lifter {
                 let INITIALIZER = header.initializer
                 var CONDITION = header.condition
                 var AFTERTHOUGHT = handleEndSingleExpressionContext(with: &w)
+                loopLabelStack.push(currentCodeLength: w.code.count)
 
                 if !INITIALIZER.contains("\n") && !CONDITION.contains("\n") && !AFTERTHOUGHT.contains("\n") {
                     if !CONDITION.isEmpty { CONDITION = " " + CONDITION }
@@ -1262,36 +1271,48 @@ public class JavaScriptLifter: Lifter {
             case .endForLoop:
                 w.leaveCurrentBlock()
                 w.emit("}")
+                loopLabelStack.pop()
+
 
             case .beginForInLoop:
                 let LET = w.declarationKeyword(for: instr.innerOutput)
                 let V = w.declare(instr.innerOutput)
                 let OBJ = input(0)
+                loopLabelStack.push(currentCodeLength: w.code.count)
                 w.emit("for (\(LET) \(V) in \(OBJ)) {")
                 w.enterNewBlock()
+
 
             case .endForInLoop:
                 w.leaveCurrentBlock()
                 w.emit("}")
+                loopLabelStack.pop()
+
 
             case .beginForOfLoop:
                 let V = w.declare(instr.innerOutput)
                 let LET = w.declarationKeyword(for: instr.innerOutput)
                 let OBJ = input(0)
+                loopLabelStack.push(currentCodeLength: w.code.count)
                 w.emit("for (\(LET) \(V) of \(OBJ)) {")
                 w.enterNewBlock()
+
 
             case .beginForOfLoopWithDestruct(let op):
                 let outputs = w.declareAll(instr.innerOutputs)
                 let PATTERN = liftArrayDestructPattern(indices: op.indices, outputs: outputs, hasRestElement: op.hasRestElement)
                 let LET = w.varKeyword
                 let OBJ = input(0)
+                loopLabelStack.push(currentCodeLength: w.code.count)
                 w.emit("for (\(LET) [\(PATTERN)] of \(OBJ)) {")
                 w.enterNewBlock()
+
 
             case .endForOfLoop:
                 w.leaveCurrentBlock()
                 w.emit("}")
+                loopLabelStack.pop()
+
 
             case .beginRepeatLoop(let op):
                 let LET = w.varKeyword
@@ -1302,12 +1323,16 @@ public class JavaScriptLifter: Lifter {
                     I = "i"
                 }
                 let ITERATIONS = op.iterations
+                loopLabelStack.push(currentCodeLength: w.code.count)
                 w.emit("for (\(LET) \(I) = 0; \(I) < \(ITERATIONS); \(I)++) {")
                 w.enterNewBlock()
+
 
             case .endRepeatLoop:
                 w.leaveCurrentBlock()
                 w.emit("}")
+                loopLabelStack.pop()
+
 
             case .loopBreak(_),
                  .switchBreak:
@@ -1361,6 +1386,7 @@ public class JavaScriptLifter: Lifter {
                 w.emit("{")
                 w.enterNewBlock()
 
+
             case .endBlockStatement:
                 w.leaveCurrentBlock()
                 w.emit("}")
@@ -1371,6 +1397,11 @@ public class JavaScriptLifter: Lifter {
             case .print:
                 let VALUE = input(0)
                 w.emit("fuzzilli('FUZZILLI_PRINT', \(VALUE));")
+
+            case .loopNestedContinue(let op):
+                w.withScriptWriter { writer in
+                    loopLabelStack.translateContinueLabel(w: &writer, expDepth: op.depth)
+                }
 
             case .createWasmGlobal(let op):
                 let V = w.declare(instr.output)
@@ -1818,6 +1849,7 @@ public class JavaScriptLifter: Lifter {
         }
     }
 
+
     /// A wrapper around a ScriptWriter. It's main responsibility is expression inlining.
     ///
     /// Expression inlining roughly works as follows:
@@ -2236,6 +2268,10 @@ public class JavaScriptLifter: Lifter {
                 return analyzer.numUses(of: v) <= 1
             }
         }
+
+        mutating func withScriptWriter(_ body: (inout ScriptWriter) -> Void) {
+            body(&writer)
+        }
     }
 
     // Helper class for formatting object literals.
@@ -2266,6 +2302,91 @@ public class JavaScriptLifter: Lifter {
             writer.leaveCurrentBlock()
             let body = writer.popTemporaryOutputBuffer()
             fields[fields.count - 1] += body + "}"
+        }
+    }
+
+    // Every possible position of label
+    struct LabelPin {
+        var beginPos: Int
+        var hasLabel: Bool
+    }
+
+    enum LabelType {
+        case loopblock
+        case ifblock
+        case switchblock
+        case tryblock
+        case codeBlock
+        case withblock
+    }
+
+    /// A structure that manages label positions within a specific control flow block (e.g., loop, if, switch, etc.).
+    public struct LabelStack {
+        let type: LabelType
+
+        private var stack: [LabelPin] = []
+
+        init(type: LabelType) {
+            self.type = type
+        }
+
+        /// Records a new label pin at the current code position.
+        mutating func push(currentCodeLength: Int) {
+            stack.append(LabelPin(beginPos: currentCodeLength, hasLabel: false))
+        }
+
+        /// Removes the most recently recorded label pin.
+        mutating func pop() {
+            _ = stack.popLast()
+        }
+
+        /// Checks whether a label has already been inserted at the specified index.
+        func labelExists(at index: Int) -> Bool {
+            return stack[index].hasLabel
+        }
+
+        /// Updates the label stack when a label is inserted into the code.
+        ///
+        /// This method:
+        /// - Marks the label at the specified index as inserted.
+        /// - Inserts the label content at the given code position.
+        /// - Shifts the positions of subsequent labels accordingly.
+        mutating func insertLabel(writer: inout ScriptWriter, at index: Int, labelContent: String) {
+            guard index < stack.count else { return }
+
+            let insertPos = stack[index].beginPos
+            writer.insert(insertPos, labelContent)
+
+            stack[index].hasLabel = true
+
+            let delta = labelContent.count
+            for i in index+1..<stack.count {
+                stack[i].beginPos += delta
+            }
+        }
+
+        mutating func translateBreakLabel(w: inout ScriptWriter, expDepth: Int){
+            let d = expDepth % stack.count
+            let pre = String(repeating: " ", count: 4 * d)
+            let s = pre + "label" + String(d) + ":\n"
+            if(!stack[d].hasLabel){
+                insertLabel(writer: &w, at: d, labelContent: s)
+            }
+            w.emit("break " + "label" + String(d) + ";")
+        }
+
+        mutating func translateContinueLabel(w: inout ScriptWriter, expDepth: Int){
+            let d = expDepth % stack.count
+            let pre = String(repeating: " ", count: 4 * d)
+            let s = pre + "label" + String(d) + ":\n"
+            if(!stack[d].hasLabel){
+                insertLabel(writer: &w, at: d, labelContent: s)
+            }
+            w.emit("continue " + "label" + String(d) + ";")
+        }
+
+        mutating func depth() -> Int{
+            return stack.count
         }
     }
 }

--- a/Sources/Fuzzilli/Lifting/ScriptWriter.swift
+++ b/Sources/Fuzzilli/Lifting/ScriptWriter.swift
@@ -84,4 +84,12 @@ struct ScriptWriter {
         assert(currentIndention.count >= indent.count)
         currentIndention.removeLast(indent.count)
     }
+
+    mutating func insert(_ pos: Int, _ content: String){
+        if code.index(code.startIndex, offsetBy: pos, limitedBy: code.endIndex) != nil {
+            let index = code.index(code.startIndex, offsetBy: pos)
+            code.insert(contentsOf: content, at: index)
+            currentLineNumber += 1
+        }
+    }
 }

--- a/Sources/Fuzzilli/Mutators/OperationMutator.swift
+++ b/Sources/Fuzzilli/Mutators/OperationMutator.swift
@@ -221,6 +221,8 @@ public class OperationMutator: BaseInstructionMutator {
             newOp = UpdateSuperProperty(propertyName: b.randomPropertyName(), operator: chooseUniform(from: BinaryOperator.allCases))
         case .beginIf(let op):
             newOp = BeginIf(inverted: !op.inverted)
+        case .loopNestedContinue(let op):
+            newOp = LoopNestedContinue(Int.random(in: 0...10))
         case .createWasmGlobal(let op):
             // The type has to match for wasm, we cannot just switch types here as the rest of the wasm code will become invalid.
             // TODO: add nullref and funcref as types here.

--- a/Sources/Fuzzilli/Protobuf/operations.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/operations.pb.swift
@@ -2922,6 +2922,7 @@ public struct Fuzzilli_Protobuf_LoopContinue: Sendable {
   public init() {}
 }
 
+
 public struct Fuzzilli_Protobuf_BeginTry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3012,6 +3013,7 @@ public struct Fuzzilli_Protobuf_EndBlockStatement: Sendable {
   public init() {}
 }
 
+
 public struct Fuzzilli_Protobuf_Nop: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3026,6 +3028,18 @@ public struct Fuzzilli_Protobuf_Print: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Fuzzilli_Protobuf_LoopNestedContinue: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var depth: Int = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -9502,6 +9516,7 @@ extension Fuzzilli_Protobuf_EndBlockStatement: SwiftProtobuf.Message, SwiftProto
   }
 }
 
+
 extension Fuzzilli_Protobuf_Nop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Nop"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -9535,6 +9550,25 @@ extension Fuzzilli_Protobuf_Print: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 
   public static func ==(lhs: Fuzzilli_Protobuf_Print, rhs: Fuzzilli_Protobuf_Print) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Fuzzilli_Protobuf_LoopNestedContinue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".LoopNestedContinue"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Fuzzilli_Protobuf_LoopNestedContinue, rhs: Fuzzilli_Protobuf_LoopNestedContinue) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Fuzzilli/Protobuf/operations.proto
+++ b/Sources/Fuzzilli/Protobuf/operations.proto
@@ -1220,6 +1220,9 @@ message WasmSelect {
     WasmILType type = 1;
 }
 
+message LoopNestedContinue {
+}
+
 message ConstSimd128 {
     repeated uint32 value = 1;
 }

--- a/Sources/Fuzzilli/Protobuf/program.pb.swift
+++ b/Sources/Fuzzilli/Protobuf/program.pb.swift
@@ -2257,6 +2257,14 @@ public struct Fuzzilli_Protobuf_Instruction: Sendable {
     set {operation = .wasmSelect(newValue)}
   }
 
+  public var loopNestedContinue: Fuzzilli_Protobuf_LoopNestedContinue {
+    get {
+      if case .loopNestedContinue(let v)? = operation {return v}
+      return Fuzzilli_Protobuf_LoopNestedContinue()
+    }
+    set {operation = .loopNestedContinue(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Operation: Equatable, Sendable {
@@ -2536,7 +2544,7 @@ public struct Fuzzilli_Protobuf_Instruction: Sendable {
     case wasmSimdLoad(Fuzzilli_Protobuf_WasmSimdLoad)
     case wasmUnreachable(Fuzzilli_Protobuf_WasmUnreachable)
     case wasmSelect(Fuzzilli_Protobuf_WasmSelect)
-
+    case loopNestedContinue(Fuzzilli_Protobuf_LoopNestedContinue)
   }
 
   public init() {}
@@ -2862,6 +2870,7 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     275: .same(proto: "wasmSimdLoad"),
     276: .same(proto: "wasmUnreachable"),
     277: .same(proto: "wasmSelect"),
+    278: .same(proto: "loopNestedContinue"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -6454,6 +6463,19 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
           self.operation = .wasmSelect(v)
         }
       }()
+      case 278: try {
+          var v: Fuzzilli_Protobuf_LoopNestedContinue?
+          var hadOneofValue = false
+          if let current = self.operation {
+            hadOneofValue = true
+            if case .loopNestedContinue(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            self.operation = .loopNestedContinue(v)
+          }
+      }()
       default: break
       }
     }
@@ -7571,6 +7593,10 @@ extension Fuzzilli_Protobuf_Instruction: SwiftProtobuf.Message, SwiftProtobuf._M
     case .wasmSelect?: try {
       guard case .wasmSelect(let v)? = self.operation else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 277)
+    }()
+    case .loopNestedContinue?: try {
+      guard case .loopNestedContinue(let v)? = self.operation else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 284)
     }()
     case nil: break
     }

--- a/Sources/Fuzzilli/Protobuf/program.proto
+++ b/Sources/Fuzzilli/Protobuf/program.proto
@@ -301,6 +301,7 @@ message Instruction {
         WasmSimdLoad wasmSimdLoad = 275;
         WasmUnreachable wasmUnreachable = 276;
         WasmSelect wasmSelect = 277;
+        LoopNestedContinue loopNestedContinue = 278;
     }
 }
 

--- a/Sources/Fuzzilli/Util/MockFuzzer.swift
+++ b/Sources/Fuzzilli/Util/MockFuzzer.swift
@@ -219,6 +219,7 @@ public func makeMockFuzzer(config maybeConfiguration: Configuration? = nil, engi
     // Use all builtin CodeGenerators
     let codeGenerators = WeightedList<CodeGenerator>(CodeGenerators.map { return ($0, codeGeneratorWeights[$0.name]!) } + WasmCodeGenerators.map { return ($0, codeGeneratorWeights[$0.name]!) })
 
+
     // Use all builtin ProgramTemplates
     let programTemplates = WeightedList<ProgramTemplate>(ProgramTemplates.map { return ($0, programTemplateWeights[$0.name]!) })
 

--- a/Tests/FuzzilliTests/LifterTest.swift
+++ b/Tests/FuzzilliTests/LifterTest.swift
@@ -2790,7 +2790,7 @@ class LifterTests: XCTestCase {
 
         XCTAssertEqual(actual, expected)
     }
-
+    
     func testSingularOperationLifting() {
         let fuzzer = makeMockFuzzer()
         let b = fuzzer.makeBuilder()
@@ -3095,4 +3095,35 @@ class LifterTests: XCTestCase {
         """
         XCTAssertEqual(actual, expected)
     }
+
+    func testLoopNestedContinueLifting(){
+        let fuzzer = makeMockFuzzer()
+        let b = fuzzer.makeBuilder()
+
+        b.buildRepeatLoop(n: 10) { 
+            b.buildRepeatLoop(n: 10) { 
+                b.buildRepeatLoop(n: 10) { 
+                    b.loopNestedContinue(2)
+                }
+                b.loopNestedContinue(1)
+            }
+        }
+        let program = b.finalize()
+        let actual = fuzzer.lifter.lift(program)
+        let expected = """
+        for (let i = 0; i < 10; i++) {
+            label1:
+            for (let i = 0; i < 10; i++) {
+                label2:
+                for (let i = 0; i < 10; i++) {
+                    continue label2;
+                }
+                continue label1;
+            }
+        }
+
+        """
+        XCTAssertEqual(actual, expected)
+    }
+    
 }


### PR DESCRIPTION
Hi Saelo,

First of all, I sincerely apologize for the long delay regarding the implementation of `LabelStatement`.
Following your suggestion #479 , I have split this feature into two separate PRs, `LoopNestedContinue `and `NestedBreak`.
This PR implements `LoopNestedContinue`. As discussed in #479, I add a new JsOperation `loopNestedContinueand`  and a new CodeGenerator `LoopNestedContinueGenerator`. Beside, the code design in `JavaScriptLifter.swift` is as follows:
1. Use `LabelStack` to trace the nested code block. 
2. The element in` LabelStack` is `LabelPin`, which has two fields: `beginPos` and `hasLabel`. `beginPos` is the index of the starting point of the js code block, and `hasLabel ` indicates whether `beginPos ` has generated a label (with a small probability of generating N lines of break or continue in the same block). 
3. Because there is no need to label every code entry with a label, which will expand the code size, it is only inserted when `continueNested ` appears. Therefore, the core operation of `LabelStack ` is `insertLabel`, which has three operations: ① Insert label string into js code; ② mark that a label has been inserted here; ③Move the positions of all LabelPins behind the stack at the corresponding depth back by the corresponding size.

Please let me know if any changes are needed; Thanks a lot!