### PR TITLE
Fixed Fuzzilli macOS swift build

### DIFF
--- a/Sources/Fuzzilli/Modules/NetworkSync.swift
+++ b/Sources/Fuzzilli/Modules/NetworkSync.swift
@@ -48,7 +48,7 @@ fileprivate protocol MessageHandler {
 /// A connection to a network peer that speaks the above protocol.
 fileprivate class Connection {
     /// The file descriptor on POSIX or SOCKET handle on Windows of the socket.
-    let socket: libsocket.socket_t
+    let socket: libsocket.libsocket_t
 
     /// The UUID of the remote end.
     let localId: UUID
@@ -78,7 +78,7 @@ fileprivate class Connection {
     /// Pending outgoing data. Must only be accessed on this connection's dispatch queue.
     private var sendQueue: [Data] = []
 
-    init?(socket: libsocket.socket_t, localId: UUID, handler: MessageHandler) {
+    init?(socket: libsocket.libsocket_t, localId: UUID, handler: MessageHandler) {
         self.socket = socket
         self.localId = localId
         self.handler = handler
@@ -331,7 +331,7 @@ public class NetworkParent: DistributedFuzzingParentNode {
         unowned let fuzzer: Fuzzer
 
         /// File descriptor or SOCKET handle of the server socket.
-        private var serverFd: libsocket.socket_t = INVALID_SOCKET
+        private var serverFd: libsocket.libsocket_t = INVALID_SOCKET
 
         /// Address and port on which to listen for connections.
         private let address: String
@@ -346,7 +346,7 @@ public class NetworkParent: DistributedFuzzingParentNode {
         private var serverQueue: DispatchQueue? = nil
 
         /// Active workers indexed by the socket used to communicate with them.
-        private var clientsBySocket = [libsocket.socket_t: Client]()
+        private var clientsBySocket = [libsocket.libsocket_t: Client]()
 
         /// Active workers indexed by their id.
         private var clientsById = [UUID: Client]()
@@ -445,7 +445,7 @@ public class NetworkParent: DistributedFuzzingParentNode {
             onChildDisconnectedCallback = callback
         }
 
-        private func handleNewConnection(_ socket: libsocket.socket_t) {
+        private func handleNewConnection(_ socket: libsocket.libsocket_t) {
             guard socket > 0 else {
                 return logger.error("Failed to accept client connection")
             }

--- a/Sources/libsocket/include/libsocket.h
+++ b/Sources/libsocket/include/libsocket.h
@@ -36,18 +36,18 @@ typedef __typeof__(_Generic((size_t)0,                                  \
                             unsigned char : (char)0)) ssize_t;
 #endif
 #else
-typedef int socket_t;
+typedef int libsocket_t;
 #define INVALID_SOCKET (-1)
 #endif
 
-socket_t socket_listen(const char* address, uint16_t port);
-socket_t socket_accept(socket_t socket);
-socket_t socket_connect(const char* address, uint16_t port);
+libsocket_t socket_listen(const char* address, uint16_t port);
+libsocket_t socket_accept(libsocket_t socket);
+libsocket_t socket_connect(const char* address, uint16_t port);
 
-ssize_t socket_send(socket_t socket, const uint8_t* data, size_t length);
-ssize_t socket_recv(socket_t socket, uint8_t* buffer, size_t length);
+ssize_t socket_send(libsocket_t socket, const uint8_t* data, size_t length);
+ssize_t socket_recv(libsocket_t socket, uint8_t* buffer, size_t length);
 
-int socket_shutdown(socket_t socket);
-int socket_close(socket_t socket);
+int socket_shutdown(libsocket_t socket);
+int socket_close(libsocket_t socket);
 
 #endif

--- a/Sources/libsocket/socket-posix.c
+++ b/Sources/libsocket/socket-posix.c
@@ -24,8 +24,8 @@
 #include <string.h>
 #include <unistd.h>
 
-socket_t socket_listen(const char* address, uint16_t port) {
-    socket_t fd = socket(AF_INET, SOCK_STREAM, 0);
+libsocket_t socket_listen(const char* address, uint16_t port) {
+    libsocket_t fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {
         return INVALID_SOCKET;
     }
@@ -54,8 +54,8 @@ socket_t socket_listen(const char* address, uint16_t port) {
     return fd;
 }
 
-socket_t socket_accept(socket_t fd) {
-    socket_t client_fd = accept(fd, NULL, 0);
+libsocket_t socket_accept(libsocket_t fd) {
+    libsocket_t client_fd = accept(fd, NULL, 0);
     if (client_fd < 0) {
         return INVALID_SOCKET;
     }
@@ -78,7 +78,7 @@ socket_t socket_accept(socket_t fd) {
     return client_fd;
 }
 
-socket_t socket_connect(const char* address, uint16_t port) {
+libsocket_t socket_connect(const char* address, uint16_t port) {
     struct addrinfo hint;
     memset(&hint, 0, sizeof(hint));
     hint.ai_family = AF_UNSPEC;
@@ -93,7 +93,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
         return INVALID_SOCKET;
     }
 
-    socket_t fd;
+    libsocket_t fd;
     struct addrinfo* addr;
     for (addr = result; addr != NULL; addr = addr->ai_next) {
         fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
@@ -133,7 +133,7 @@ socket_t socket_connect(const char* address, uint16_t port) {
     return fd;
 }
 
-ssize_t socket_send(socket_t fd, const uint8_t* data, size_t length) {
+ssize_t socket_send(libsocket_t fd, const uint8_t* data, size_t length) {
     ssize_t remaining = length;
     while (remaining > 0) {
 #ifdef __APPLE__
@@ -154,15 +154,15 @@ ssize_t socket_send(socket_t fd, const uint8_t* data, size_t length) {
     return length;
 }
 
-ssize_t socket_recv(socket_t fd, uint8_t* data, size_t length) {
+ssize_t socket_recv(libsocket_t fd, uint8_t* data, size_t length) {
     return read(fd, data, length);
 }
 
-int socket_shutdown(socket_t socket) {
+int socket_shutdown(libsocket_t socket) {
     return shutdown(socket, SHUT_RDWR);
 }
 
-int socket_close(socket_t fd) {
+int socket_close(libsocket_t fd) {
     return close(fd);
 }
 


### PR DESCRIPTION
Renamed `socket_t` to `libsocket_t` to resolve swift build issue

Swift build error before variable renaming

```
fuzzilli % swift build -c release
[1/1] Planning build
Building for production...
error: compile command failed due to signal 6 (use -v to see invocation)
<unknown>:0: error: reference to 'socket_t' is ambiguous
Failed to reconstruct type for $sSo8socket_taD
Original type:
(type_alias_type decl="libsocket.(file).socket_t@/Users/emma/fuzzilli/Sources/libsocket/include/libsocket.h:39:13"
  (underlying=struct_type decl="Swift.(file).Int32"))
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Pass '-Xfrontend -disable-round-trip-debug-types' to disable this assertion.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/emma/fuzzilli/Sources/Fuzzilli/Base/Component.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Base/Contributor.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Base/Events.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Base/Logging.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Base/ProgramBuilder.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Base/ProgramOrigin.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Base/Timers.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/CodeGenerator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/CodeGeneratorWeights.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/CodeGenerators.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/ProgramTemplate.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/ProgramTemplateWeights.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/ProgramTemplates.swift /Users/emma/fuzzilli/Sources/Fuzzilli/CodeGen/WasmCodeGenerators.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Compiler/Compiler.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Compiler/JavaScriptParser.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Configuration.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Corpus/BasicCorpus.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Corpus/Corpus.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Corpus/MarkovCorpus.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Engines/FuzzEngine.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Engines/FuzzingPostProcessor.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Engines/GenerativeEngine.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Engines/HybridEngine.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Engines/MultiEngine.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Engines/MutationEngine.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Environment/Environment.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Environment/JavaScriptEnvironment.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Evaluation/ProgramAspects.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Evaluation/ProgramCoverageEvaluator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Evaluation/ProgramEvaluator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Execution/Execution.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Execution/REPRL.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Execution/ScriptRunner.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Analyzer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Blocks.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Code.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Context.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Instruction.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/JSTyper.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/JsOperations.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Opcodes.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Operation.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Program.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/ProgramComments.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Semantics.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/TypeSystem.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/Variable.swift /Users/emma/fuzzilli/Sources/Fuzzilli/FuzzIL/WasmOperations.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Fuzzer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/Expression.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/FuzzILLifter.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/JSExpressions.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/JavaScriptExploreLifting.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/JavaScriptFixupLifting.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/JavaScriptLifter.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/JavaScriptProbeLifting.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/JavaScriptRuntimeAssistedMutatorLifting.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/Lifter.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/ScriptWriter.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Lifting/WasmLifter.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/BlockReducer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/DataFlowSimplifier.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/DeduplicatingReducer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/GenericInstructionReducer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/InliningReducer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/InstructionSimplifier.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/LoopSimplifier.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/MinimizationHelper.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/MinimizationPostProcessor.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/Minimizer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/ReassignReducer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Minimization/VariadicInputReducer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/Module.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/NetworkSync.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/Statistics.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/Storage.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/Sync.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/ThreadSync.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/BaseInstructionMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/CodeGenMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/CombineMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/ConcatMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/ExplorationMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/FixupMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/InputMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/Mutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/MutatorSettings.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/OperationMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/ProbingMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/RuntimeAssistedMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Mutators/SpliceMutator.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Protobuf/ProtoUtils.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Protobuf/ast.pb.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Protobuf/operations.pb.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Protobuf/program.pb.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Protobuf/sync.pb.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/Arguments.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/CInterop.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/Error.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/JavaScriptExecutor.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/Leb128.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/Misc.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/MockFuzzer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/MovingAverage.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/Random.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/RingBuffer.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/Stack.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/VariableMap.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/VariableSet.swift /Users/emma/fuzzilli/Sources/Fuzzilli/Util/WeightedList.swift /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/DerivedSources/resource_bundle_accessor.swift -supplementary-output-file-map /var/folders/t4/s47_ld1n26309w9xnx916v4c0000gn/T/TemporaryDirectory.ymXoSg/supplementaryOutputs-1 -target x86_64-apple-macosx11.0 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -I /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Modules -I /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/lib/swift/macosx/testing -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks -color-diagnostics -g -debug-info-format=dwarf -dwarf-version=4 -module-cache-path /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/ModuleCache -swift-version 5 -O -D SWIFT_PACKAGE -empty-abi-descriptor -plugin-path /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/lib/swift/host/plugins/testing -resource-dir /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/lib/swift -file-compilation-dir /Users/emma/fuzzilli -Xcc -fmodule-map-file=/Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/libsocket.build/module.modulemap -Xcc -I -Xcc /Users/emma/fuzzilli/Sources/libsocket/include -Xcc -fmodule-map-file=/Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/libreprl.build/module.modulemap -Xcc -I -Xcc /Users/emma/fuzzilli/Sources/libreprl/include -Xcc -fmodule-map-file=/Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/libcoverage.build/module.modulemap -Xcc -I -Xcc /Users/emma/fuzzilli/Sources/libcoverage/include -Xcc -isysroot -Xcc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -Xcc -F -Xcc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -Xcc -F -Xcc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks -Xcc -fPIC -Xcc -g -module-name Fuzzilli -in-process-plugin-server-path /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -plugin-path /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Users/ret2/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/local/lib/swift/host/plugins -target-sdk-version 15.5 -target-sdk-name macosx15.5 -external-plugin-path /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins#/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/local/lib/swift/host/plugins#/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server -enable-default-cmo -parse-as-library -num-threads 16 -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Component.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Contributor.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Events.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Logging.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramBuilder.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramOrigin.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Timers.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/CodeGenerator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/CodeGeneratorWeights.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/CodeGenerators.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramTemplate.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramTemplateWeights.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramTemplates.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/WasmCodeGenerators.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Compiler.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptParser.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Configuration.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/BasicCorpus.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Corpus.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MarkovCorpus.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/FuzzEngine.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/FuzzingPostProcessor.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/GenerativeEngine.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/HybridEngine.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MultiEngine.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MutationEngine.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Environment.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptEnvironment.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramAspects.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramCoverageEvaluator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramEvaluator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Execution.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/REPRL.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ScriptRunner.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Analyzer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Blocks.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Code.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Context.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Instruction.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JSTyper.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JsOperations.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Opcodes.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Operation.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Program.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProgramComments.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Semantics.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/TypeSystem.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Variable.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/WasmOperations.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Fuzzer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Expression.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/FuzzILLifter.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JSExpressions.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptExploreLifting.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptFixupLifting.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptLifter.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptProbeLifting.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptRuntimeAssistedMutatorLifting.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Lifter.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ScriptWriter.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/WasmLifter.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/BlockReducer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/DataFlowSimplifier.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/DeduplicatingReducer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/GenericInstructionReducer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/InliningReducer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/InstructionSimplifier.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/LoopSimplifier.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MinimizationHelper.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MinimizationPostProcessor.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Minimizer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ReassignReducer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/VariadicInputReducer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Module.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/NetworkSync.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Statistics.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Storage.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Sync.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ThreadSync.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/BaseInstructionMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/CodeGenMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/CombineMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ConcatMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ExplorationMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/FixupMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/InputMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Mutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MutatorSettings.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/OperationMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProbingMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/RuntimeAssistedMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/SpliceMutator.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ProtoUtils.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/ast.pb.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/operations.pb.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/program.pb.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/sync.pb.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Arguments.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/CInterop.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Error.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/JavaScriptExecutor.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Leb128.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Misc.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MockFuzzer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/MovingAverage.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Random.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/RingBuffer.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/Stack.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/VariableMap.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/VariableSet.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/WeightedList.swift.o -o /Users/emma/fuzzilli/.build/x86_64-apple-macosx/release/Fuzzilli.build/resource_bundle_accessor.swift.o
1.	Apple Swift version 6.1.2 (swift-6.1.2-RELEASE)
2.	Compiling with effective version 5.10
3.	While emitting IR SIL function "@$s8Fuzzilli12NetworkChildC9Transport33_9671F4CFB1F60B3D4B347309A2533817LLC7connectyyF".
 for 'connect()' (at /Users/emma/fuzzilli/Sources/Fuzzilli/Modules/NetworkSync.swift:552:17)
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x000000010b20ff98 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 40
1  swift-frontend           0x000000010b20e395 llvm::sys::RunSignalHandlers() + 85
2  swift-frontend           0x000000010b2105f6 SignalHandler(int) + 278
3  libsystem_platform.dylib 0x00007ff80ec5825d _sigtramp + 29
4  libsystem_platform.dylib 0x00007f9436cc1401 _sigtramp + 18446743644884341185
5  libsystem_c.dylib        0x00007ff80eb3e73e abort + 126
6  swift-frontend           0x000000010b39a37d (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateType(swift::irgen::DebugTypeInfo, llvm::DIScope*) (.cold.21) + 141
7  swift-frontend           0x00000001051ad972 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateType(swift::irgen::DebugTypeInfo, llvm::DIScope*) + 5250
8  swift-frontend           0x00000001051a65b6 (anonymous namespace)::IRGenDebugInfoImpl::emitVariableDeclaration(swift::irgen::IRBuilder&, llvm::ArrayRef<llvm::Value*>, swift::irgen::DebugTypeInfo, swift::SILDebugScope const*, std::__1::optional<swift::SILLocation>, swift::SILDebugVariable, swift::irgen::IndirectionKind, swift::irgen::ArtificialKind, swift::irgen::AddrDbgInstrKind) + 582
9  swift-frontend           0x00000001051a6332 swift::irgen::IRGenDebugInfo::emitVariableDeclaration(swift::irgen::IRBuilder&, llvm::ArrayRef<llvm::Value*>, swift::irgen::DebugTypeInfo, swift::SILDebugScope const*, std::__1::optional<swift::SILLocation>, swift::SILDebugVariable, swift::irgen::IndirectionKind, swift::irgen::ArtificialKind, swift::irgen::AddrDbgInstrKind) + 290
10 swift-frontend           0x0000000105212e18 (anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*) + 94360
11 swift-frontend           0x00000001051fae90 (anonymous namespace)::IRGenSILFunction::emitSILFunction() + 12400
12 swift-frontend           0x00000001051f77ca swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 2634
13 swift-frontend           0x000000010505ae7b swift::irgen::IRGenerator::emitLazyDefinitions() + 2491
14 swift-frontend           0x0000000105197b31 swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm::GlobalVariable**) + 3377
15 swift-frontend           0x0000000104bcc7ab generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>) + 267
16 swift-frontend           0x0000000104bc86e0 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 1504
17 swift-frontend           0x0000000104bc7d6d swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 1869
18 swift-frontend           0x0000000104bd5abf withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) + 143
19 swift-frontend           0x0000000104bc9da9 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 985
20 swift-frontend           0x0000000104bc9322 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2850
21 swift-frontend           0x000000010498290f swift::mainEntry(int, char const**) + 3423
22 dyld                     0x00007ff80e87a530 start + 3056
```