### PR TITLE
Fix Win32 compilation failure

### DIFF
--- a/Sources/Fuzzilli/Util/JavaScriptExecutor.swift
+++ b/Sources/Fuzzilli/Util/JavaScriptExecutor.swift
@@ -14,6 +14,10 @@
 
 import Foundation
 
+#if os(Windows)
+import WinSDK
+#endif /* os(Windows) */
+
 public class JavaScriptExecutor {
     /// Path to the js shell binary.
     let executablePath: String
@@ -103,11 +107,21 @@ public class JavaScriptExecutor {
                     break
                 }
             }
-            if task.isRunning {
+            runningCheck: if task.isRunning {
+                timedOut = true
+#if os(Windows)
+                guard let processHandle = OpenProcess(DWORD(PROCESS_TERMINATE), false, DWORD(task.processIdentifier)) else {
+                    // Fall back to built-in termination
+                    task.terminate()
+                    break runningCheck
+                }
+                defer { CloseHandle(processHandle) }
+                TerminateProcess(processHandle, 1)
+#else
                 // Properly kill the task now with SIGKILL as it might be stuck
                 // in Wasm, where SIGTERM is not enough.
                 kill(task.processIdentifier, SIGKILL)
-                timedOut = true
+#endif /* os(Windows) */
             }
         }
 

--- a/Sources/libsocket/include/libsocket.h
+++ b/Sources/libsocket/include/libsocket.h
@@ -22,7 +22,7 @@
 #endif
 
 #if defined(_WIN32)
-typedef SOCKET socket_t;
+typedef SOCKET libsocket_t;
 
 // We need C11 or newer due to the use of `_Generic`.  Windows does not have a
 // signed size type, so we construct the equivalent type by inspecting the type

--- a/Sources/libsocket/socket-win32.c
+++ b/Sources/libsocket/socket-win32.c
@@ -44,8 +44,8 @@ static void __attribute__((__destructor__, __used__)) libsocket_fini(void) {
     (void)WSACleanup();
 }
 
-socket_t socket_listen(const char *address, uint16_t port) {
-    socket_t sock = socket(AF_INET, SOCK_STREAM, 0);
+libsocket_t socket_listen(const char *address, uint16_t port) {
+    libsocket_t sock = socket(AF_INET, SOCK_STREAM, 0);
     if (sock == INVALID_SOCKET)
         return INVALID_SOCKET;
 
@@ -68,8 +68,8 @@ socket_t socket_listen(const char *address, uint16_t port) {
     return sock;
 }
 
-socket_t socket_accept(socket_t sock) {
-    socket_t client = accept(sock, NULL, NULL);
+libsocket_t socket_accept(libsocket_t sock) {
+    libsocket_t client = accept(sock, NULL, NULL);
     if (client == INVALID_SOCKET)
         return INVALID_SOCKET;
 
@@ -82,7 +82,7 @@ socket_t socket_accept(socket_t sock) {
     return client;
 }
 
-socket_t socket_connect(const char *address, uint16_t port) {
+libsocket_t socket_connect(const char *address, uint16_t port) {
     struct addrinfo ai;
     ZeroMemory(&ai, sizeof(ai));
     ai.ai_family = AF_UNSPEC;
@@ -96,7 +96,7 @@ socket_t socket_connect(const char *address, uint16_t port) {
     if (getaddrinfo(address, port_str, &ai, &ai_list))
         return INVALID_SOCKET;
 
-    socket_t sock;
+    libsocket_t sock;
     struct addrinfo *ai_cur;
     for (ai_cur = ai_list; ai_cur; ai_cur = ai_cur->ai_next) {
         sock = socket(ai_cur->ai_family, ai_cur->ai_socktype, ai_cur->ai_protocol);
@@ -124,7 +124,7 @@ socket_t socket_connect(const char *address, uint16_t port) {
     return sock;
 }
 
-ssize_t socket_send(socket_t sock, const uint8_t *data, size_t length) {
+ssize_t socket_send(libsocket_t sock, const uint8_t *data, size_t length) {
     assert(length <= INT_MAX && "unable to send > INT_MAX bytes");
     ssize_t remaining = length;
     while (remaining) {
@@ -137,16 +137,16 @@ ssize_t socket_send(socket_t sock, const uint8_t *data, size_t length) {
     return length;
 }
 
-ssize_t socket_recv(socket_t sock, uint8_t *buffer, size_t length) {
+ssize_t socket_recv(libsocket_t sock, uint8_t *buffer, size_t length) {
     assert(length <= INT_MAX && "unable to receive >INT_MAX bytes");
     return recv(sock, (char *)buffer, length, 0);
 }
 
-int socket_shutdown(socket_t socket) {
+int socket_shutdown(libsocket_t socket) {
     return shutdown(socket, SD_BOTH);
 }
 
-int socket_close(socket_t socket) {
+int socket_close(libsocket_t socket) {
     return closesocket(socket);
 }
 


### PR DESCRIPTION
This PR adds two fixes for successful compilation on Win32:

* dffd0937fa07736bd370d0c5d61fc0eb815113d7: Port #515 to win32.
* 9f37953d784a8c8197932d9f814277b222d4d3d6: Add Win32-specialized code for terminating timed out tasks.