### PR TITLE
Update README for `Targets/JavaScriptCore/README.md`

### DIFF
--- a/Targets/JavaScriptCore/README.md
+++ b/Targets/JavaScriptCore/README.md
@@ -6,4 +6,4 @@ To build JavaScriptCore (jsc) for fuzzing:
 2. Apply Patches/\*. The patches should apply cleanly to the git revision specified in [./REVISION](./REVISION)
    (_Note_: If you clone WebKit from `git.webkit.org`, the commit hash will differ)
 3. Run the fuzzbuild.sh script in the webkit root directory
-4. FuzzBuild/Debug/bin/jsc will be the JavaScript shell for the fuzzer
+4. WebKitBuild/Fuzzilli/bin/jsc will be the JavaScript shell for the fuzzer


### PR DESCRIPTION
Fixes outdated build directory path