### PR TITLE
Pass environment variables to the engine in startup tests

### DIFF
--- a/Sources/Fuzzilli/Execution/REPRL.swift
+++ b/Sources/Fuzzilli/Execution/REPRL.swift
@@ -25,7 +25,7 @@ public class REPRL: ComponentBase, ScriptRunner {
     public private(set) var processArguments: [String]
 
     /// Environment variables for the child process. Shape: [(key, value)]
-    private var env = [(String, String)]()
+    public private(set) var env = [(String, String)]()
 
     /// Number of script executions since start of child process
     private var execsSinceReset = 0

--- a/Sources/Fuzzilli/Execution/ScriptRunner.swift
+++ b/Sources/Fuzzilli/Execution/ScriptRunner.swift
@@ -14,6 +14,7 @@
 
 public protocol ScriptRunner: Component {
     var processArguments: [String] { get }
+    var env: [(String, String)] { get }
 
     /// Executes a script, waits for it to complete, and returns the result.
     func run(_ script: String, withTimeout timeout: UInt32) -> Execution

--- a/Sources/Fuzzilli/Fuzzer.swift
+++ b/Sources/Fuzzilli/Fuzzer.swift
@@ -1013,7 +1013,9 @@ public class Fuzzer {
 
         // Wrap the executor in a JavaScriptTestRunner
         // If we can execute it standalone, it could inform us if any flags that were passed are incorrect, stale or conflicting.
-        let executor = JavaScriptExecutor(withExecutablePath: runner.processArguments[0], arguments: Array(runner.processArguments[1...]))
+        let executor = JavaScriptExecutor(
+            withExecutablePath: runner.processArguments[0],
+            arguments: Array(runner.processArguments[1...]), env: runner.env)
         do {
             let output = try executor.executeScript("", withTimeout: 300).output
             if output.lengthOfBytes(using: .utf8) > 0 {

--- a/Sources/Fuzzilli/Util/MockFuzzer.swift
+++ b/Sources/Fuzzilli/Util/MockFuzzer.swift
@@ -26,6 +26,7 @@ struct MockExecution: Execution {
 
 class MockScriptRunner: ScriptRunner {
     var processArguments: [String] = []
+    var env: [(String, String)] = []
 
     func run(_ script: String, withTimeout timeout: UInt32) -> Execution {
         return MockExecution(outcome: .succeeded,


### PR DESCRIPTION
This PR helps avoid potential mismatches in behavior between a startup test and subsequent fuzzing based on REPRL sessions.

After this patch, the startup tests on SpiderMonkey produce the following output:

```plain-text
[Fuzzer] Initialized
[Fuzzer] Recommended timeout: at least 1000ms. Current timeout: 10000ms
[Fuzzer] Runner has non-empty output for empty program! This might indicate that some flags are wrong.
[Fuzzer] Output:
[COV] edge counters initialized. Shared memory: shm_id_230610_0 with 398403 edges
```

Resolves #534.