### PR TITLE
[v8] Randomize some fuzzing flags

### DIFF
--- a/Sources/Fuzzilli/Profiles/V8CommonProfile.swift
+++ b/Sources/Fuzzilli/Profiles/V8CommonProfile.swift
@@ -959,6 +959,8 @@ public func v8ProcessArgs(randomize: Bool, forSandbox: Bool) -> [String] {
         args.append("--sandbox-fuzzing")
         // This is so that we get an ASan splat directly in the reproducer file.
         args.append("--disable-in-process-stack-traces")
+        // Disable extra stress-testing that might trigger benign CHECKs and mask actual sandbox violations.
+        args.append("--no-stress-lazy-source-positions")
     }
 
     guard randomize else { return args }
@@ -1232,6 +1234,12 @@ public func v8ProcessArgs(randomize: Bool, forSandbox: Bool) -> [String] {
         chooseBooleanFlag("force-slow-path")
         chooseBooleanFlag("lazy")
         chooseBooleanFlag("lazy-eval")
+        chooseBooleanFlag("baseline-batch-compilation")
+        chooseBooleanFlag("lazy-feedback-allocation")
+        chooseBooleanFlag("stress-branch-hinting")
+        if !forSandbox {
+            chooseBooleanFlag("stress-lazy-source-positions")
+        }
 
         // Maglev related flags
         chooseBooleanFlag("maglev-inline-api-calls")


### PR DESCRIPTION
Randomly pick up the values for "baseline-batch-compilation", "lazy-feedback-allocation", "stress-branch-hinting".

Also do the same for "stress-lazy-source-positions", but only in non-sandbox fuzzing sessions: this stress enables additional CHECKs that are ignored by V8's sandbox fuzzer crash filters, and hence may result in masking real issues from the fuzzer.

Note that V8 currently has implications from "--fizzing" and "--jit-fuzzing" that will take precedence over some of these random selections, however this is about to change (see
https://crbug.com/475707969).